### PR TITLE
MEM-551 Upgrade to ArcGIS API v4.5.0

### DIFF
--- a/src/app/map/map-loader.service.ts
+++ b/src/app/map/map-loader.service.ts
@@ -106,7 +106,7 @@ export class MapLoaderService {
   private loadArcgis(): Promise<Function> {
     return this.esriLoader.load({
       // use a specific version of the API instead of the latest
-      url: 'https://js.arcgis.com/4.4/'
+      url: 'https://js.arcgis.com/4.5/'
     });
   }
 }


### PR DESCRIPTION
Fixes 3rd-party bug:

**BUG-000104472:** Setting the `rotationEnabled` property of the MapView's constraints property to 'false'
no longer causes problems using pinch while zooming in/out on mobile devices.