### PR TITLE
MEM-627 Use DataBC Physical Address Geocoder for location search

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/jasmine": "2.5.38",
     "@types/lodash": "4.14.80",
     "@types/node": "~6.0.60",
+    "@types/geojson": "7946.0.0",
     "codelyzer": "~2.0.0",
     "jasmine-core": "~2.5.2",
     "jasmine-spec-reporter": "~3.2.0",

--- a/src/app/map/config/index.ts
+++ b/src/app/map/config/index.ts
@@ -1,2 +1,1 @@
-export { MapConfig } from './map-config.interface';
-export { MapConfigService } from './map-config.service';
+export { MapConfig, MapConfigService } from './map-config.service';

--- a/src/app/map/config/map-config.interface.ts
+++ b/src/app/map/config/map-config.interface.ts
@@ -1,7 +1,0 @@
-export interface MapConfig {
-  mainMap?: {
-    webmap?: __esri.WebMapProperties,
-    mapView?: __esri.MapViewProperties,
-    popup?: __esri.PopupTemplateProperties
-  };
-}

--- a/src/app/map/config/map-config.service.ts
+++ b/src/app/map/config/map-config.service.ts
@@ -1,13 +1,22 @@
 import { Injectable } from '@angular/core';
 
 import { Api } from 'app/services/api';
-import { MapConfig } from './map-config.interface';
+import { GeocoderSettings } from '../widgets/support/geocoder';
 
 const webmaps = {
   dev: 'b8ea19982bd74db3bd968d3c7f038e43',
   test: 'b8ea19982bd74db3bd968d3c7f038e43',
   prod: 'b8ea19982bd74db3bd968d3c7f038e43'
 };
+
+export interface MapConfig {
+  mainMap?: {
+    webmap?: __esri.WebMapProperties,
+    mapView?: __esri.MapViewProperties,
+    popup?: __esri.PopupTemplateProperties,
+    geocoder?: GeocoderSettings;
+  };
+}
 
 @Injectable()
 export class MapConfigService {
@@ -30,7 +39,10 @@ export class MapConfigService {
             components: ['attribution']
           }
         },
-        popup: this.defaultPopupTemplate
+        popup: this.defaultPopupTemplate,
+        geocoder: {
+          type: 'databc',  // One of: [databc, arcgis]
+        }
       }
     };
   }

--- a/src/app/map/map.module.ts
+++ b/src/app/map/map.module.ts
@@ -7,6 +7,8 @@ import { EsriMapComponent } from './esri-map/esri-map.component';
 import { MainMapComponent } from './main-map/main-map.component';
 import { ProjectMapComponent } from './project-map/project-map.component';
 import { MapLoaderService } from './map-loader.service';
+import { MapConfigService } from './config/map-config.service';
+import { WidgetBuilder } from './widgets/widget-builder';
 
 @NgModule({
   imports: [
@@ -25,7 +27,9 @@ import { MapLoaderService } from './map-loader.service';
     ProjectMapComponent
   ],
   providers: [
-    MapLoaderService
+    MapConfigService,
+    MapLoaderService,
+    WidgetBuilder
   ]
 })
 export class MapModule { }

--- a/src/app/map/project-map/project-map.component.ts
+++ b/src/app/map/project-map/project-map.component.ts
@@ -7,9 +7,6 @@ import { Project } from '../../models/project';
   selector: 'app-project-map',
   templateUrl: './project-map.component.html',
   styleUrls: ['./project-map.component.scss'],
-  providers: [
-    MapConfigService
-  ]
 })
 export class ProjectMapComponent implements OnInit {
   // public properties

--- a/src/app/map/widgets/support/geocoder-api.ts
+++ b/src/app/map/widgets/support/geocoder-api.ts
@@ -1,0 +1,200 @@
+export function createRequestBuilder(baseUrl: string): RequestBuilder {
+  return new RequestBuilder(baseUrl);
+}
+
+class RequestBuilder {
+  // required
+  private _baseUrl: string;
+  private _outputFormat: string;
+  private _addressString: string;
+
+  // optional
+  private _minScore: number;
+  private _maxResults: number;
+  private _outputSRS: number;
+
+  private _echo = false;
+  private _autoComplete = false;
+
+  // search within an area (bounding box)
+  private _bbox: string;  // A bounding box (xmin,ymin,xmax,ymax) that limits the search area
+
+  // search within an area (centre point + distance in meters)
+  private _centre: string;  // The coordinates of a centre point (x,y) used to define a bounding circle that will limit the search area
+  private _maxDistance: number;
+
+  constructor(baseUrl: string) {
+    this._baseUrl = baseUrl || 'https://apps.gov.bc.ca/pub/geocoder';
+    this._outputFormat = 'json';
+    this._outputSRS = 4326;  // --> WGS84 (default map projection)
+  }
+
+  /**
+   * Specifies the format of the return geocoding results.
+   * Valid outputFormat parameters are: csv, json, geojson, gml, kml, shpz, xhtml
+   */
+  setOutputFormat(value: string): RequestBuilder {
+    this._outputFormat = value;
+    return this;
+  }
+  get outputFormat(): string {
+    return this._outputFormat;
+  }
+
+  /**
+   * Specifies the address to be geocoded as a single string
+   */
+  setAddress(address: string): RequestBuilder {
+    this._addressString = address;
+    return this;
+  }
+  get address(): string {
+    return this._addressString;
+  }
+
+  /**
+   * Specifies the minimum acceptable score of returned results.
+   * Results with scores lower than this will not be returned. The score
+   * value ranges from 0-100; a minScore of 0 returns all results.
+   */
+  setMinScore(value: number): RequestBuilder {
+    this._minScore = value;
+    return this;
+  }
+  get minScore(): number {
+    return this._minScore;
+  }
+
+  /**
+   * Specifies the maximum number of results to return. This is applied after the `minScore` requirement.
+   * It is intended to prevent unnecessary overhead while waiting for a large, complete list of results
+   * to return when only a short list of the best matches is required. Setting maxResults to 0 will
+   * return the maximum number of results allowable by the system.
+   */
+  setMaxResults(value: number): RequestBuilder {
+    this._maxResults = value;
+    return this;
+  }
+  get maxResults(): number {
+    return this._maxResults;
+  }
+
+  /**
+   * Specifies the Spatial Referencing System (SRS) to use for the locations in the results.
+   * Many SRS's are supported but it only makes sense to use an SRS which is valid for area in which the
+   * results are. SRS's are specified using their EPSG code, an integer generally in the range of 1-1,000,000.
+   * Common examples are 3005 (BC Albers) and 4326 (Geographic) which is the default.
+   */
+  setOutputSRS(value: number): RequestBuilder {
+    this._outputSRS = value;
+    return this;
+  }
+  get outputSRS(): number {
+    return this._outputSRS;
+  }
+
+  /**
+   * Specifies whether to echo back unmatched address information in the results.
+   * For example, with echo enabled, an apartment number or site name specified in the address query,
+   * but which is not present in the database, is still included in the results.
+   */
+  setEcho(value: boolean): RequestBuilder {
+    this._echo = value;
+    return this;
+  }
+  get echo(): boolean {
+    return this._echo;
+  }
+
+  /**
+   * If `true`, addressString is expected to contain a partial address that requires completion.
+   * Not supported for `shp`, `csv`, `gml` formats.
+   */
+  setAutoComplete(value: boolean): RequestBuilder {
+    this._autoComplete = value;
+    return this;
+  }
+  get autoComplete(): boolean {
+    return this._autoComplete;
+  }
+
+  /**
+   * Specifies a rectangular geographic area used to filter results of a query.
+   * Coordinates are specified as xmin,ymin,xmax,ymax. By default, coordinates are
+   * longitude minimum, latitude minimum, longitude maximum, latitude maximum in the
+   * default output SRS, 4326 (WGS84).
+   */
+  setBBox(bbox: string): RequestBuilder {
+    this._bbox = bbox;
+    return this;
+  }
+  get bbox(): string {
+    return this._bbox;
+  }
+
+  /**
+   * Specifies the coordinates of a centre point (x,y) used to define a bounding circle
+   * that will limit the search area. `centre` and `maxDistance` together define a search area.
+   */
+  setCentre(point: string): RequestBuilder {
+    this._centre = point;
+    return this;
+  }
+  get centre(): string {
+    return this._centre;
+  }
+
+  /**
+   * Specifies the maximum distance (in metres) to search from the given point.
+   * If not specified, the maximum distance is unlimited.
+   */
+  setMaxDistance(value: number): RequestBuilder {
+    this._maxDistance = value;
+    return this;
+  }
+  get maxDistance(): number {
+    return this._maxDistance;
+  }
+
+  /**
+   * Combines all of the request parameters into a single request URL.
+   * This url can then be used, for example, to navigate to or in an AJAX request.
+   * @returns the URL used to get the results of the geocode request
+   */
+  build(): string {
+    let url = this._baseUrl + '/addresses';
+    if (this._outputFormat) {
+      url += '.' + encodeURIComponent(this._outputFormat);
+    }
+    url += '?';
+    if (this._addressString) {
+      url += 'addressString=' + encodeURIComponent(this._addressString) + '&';
+    }
+    // optional args
+    if (typeof this._maxResults !== 'undefined') {
+      url += 'maxResults=' + this._maxResults + '&';
+    }
+    if (typeof this._minScore !== 'undefined') {
+      url += 'minScore=' + this._minScore + '&';
+    }
+    if (this._centre) {
+      url += 'centre=' + encodeURIComponent(this._centre) + '&';
+    }
+    if (this._maxDistance) {
+      url += 'maxDistance=' + this._maxDistance + '&';
+    }
+    if (this._bbox) {
+      url += 'bbox=' + encodeURIComponent(this._bbox) + '&';
+    }
+    if (typeof this._echo !== 'undefined') {
+      url += 'echo=' + this._echo + '&';
+    }
+    if (typeof this._autoComplete !== 'undefined') {
+      url += 'autoComplete=' + this._autoComplete + '&';
+    }
+    if (this._outputSRS) {
+      url += 'outputSRS=' + this._outputSRS + '&';
+    }
+    return url;
+  }
+}

--- a/src/app/map/widgets/support/geocoder.ts
+++ b/src/app/map/widgets/support/geocoder.ts
@@ -1,0 +1,217 @@
+import * as _ from 'lodash';
+import { Http } from '@angular/http';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/toPromise';
+
+import { Feature, FeatureCollection, Point } from 'geojson';
+import { createRequestBuilder } from './geocoder-api';
+import { EsriLoaderService } from 'angular-esri-loader';
+
+// The following "type" declarations do not generate code.
+// They just provide better intellisense and type checking with TypeScript.
+//
+// ArcGIS tweaks and fixes (node_modules/@types/arcgis-js-api/index.d.ts)
+//   - adds undocumented `maxSuggestions` property to geocoder configuration.
+//   - fixes `esri/request` type definition.
+type LocatorSuggestLocationsParams = __esri.LocatorSuggestLocationsParams & { maxSuggestions?: number };
+type EsriRequest = (url: string, options?: __esri.requestEsriRequestOptions) => IPromise<any>;
+interface EsriResponse {
+  /** The requested data. */
+  data?: any;
+  /** The options specified by the user in the data request. */
+  requestOptions?: __esri.requestEsriRequestOptions;
+  /** The URL used to request the data. */
+  url?: string;
+  /** Method for getting a header sent from the server. */
+  getHeader?: __esri.GetHeader;
+}
+
+// GeoJSON response sent back by DataBC address locator
+// https://github.com/bcgov/api-specs/blob/master/geocoder/geocoder-developer-guide.md#resource-representations-in-http-responses
+type GeocodeAddressResults = ServerMetadata & FeatureCollection<Point>;
+interface ServerMetadata {
+  queryAddress?: string;
+  searchTimestamp?: string;
+  version?: string;
+  executionTime?: number;
+  srsCode?: number;
+  maxResults?: number;
+  disclaimer?: string;
+  privacyStatement?: string;
+  copyrightNotice?: string;
+  copyrightLicense?: string;
+}
+
+export interface GeocoderSettings {
+  type?: string;
+  url?: string;
+  suggestUrl?: string;
+}
+
+export function singleLineFieldName(options: GeocoderSettings = {}): string {
+  return options.type === 'databc' ? 'addressString' : 'SingleLine';
+}
+
+export function createGeocoder(esriLoader: EsriLoaderService, options: GeocoderSettings = {}): Promise<__esri.Locator> {
+  if (options.type === 'databc') {
+    return createDataBcGeocoder(esriLoader, options);
+  } else {
+    return createArcgisGeocoder(esriLoader, options);  // default
+  }
+}
+
+function createArcgisGeocoder(esriLoader: EsriLoaderService, options: GeocoderSettings = {}): Promise<__esri.Locator> {
+  const url = options.url || '//geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer';
+  return esriLoader.loadModules(['esri/tasks/Locator'])
+    .then(([Locator]: [__esri.LocatorConstructor]) => new Locator({ url: url }));
+}
+
+function createDataBcGeocoder(esriLoader: EsriLoaderService, options: GeocoderSettings = {}): Promise<__esri.Locator> {
+  const url = options.url || 'https://apps.gov.bc.ca/pub/geocoder';
+  return createClass(esriLoader, options)
+    .then((DataBcLocator: __esri.LocatorConstructor) => new DataBcLocator({ url: url }));
+}
+
+/**
+ * Creates a geocoder class that leverages the DataBC Geocoder API
+ * https://raw.githubusercontent.com/bcgov/api-specs/master/geocoder/geocoder.json
+ */
+function createClass(esriLoader: EsriLoaderService, options: GeocoderSettings = {}): Promise<__esri.LocatorConstructor> {
+  return esriLoader.loadModules([
+    'esri/tasks/Locator',
+    'esri/tasks/support/AddressCandidate',
+    'esri/geometry/support/webMercatorUtils',
+    'esri/geometry/SpatialReference',
+    'esri/request',
+    'esri/config'])
+    .then((modules: [
+      __esri.LocatorConstructor,
+      __esri.AddressCandidateConstructor,
+      __esri.webMercatorUtils,
+      __esri.SpatialReference,
+      EsriRequest,
+      __esri.config]) => {
+
+      const [Locator, AddressCandidate, webMercatorUtils, SpatialReference, esriRequest, esriConfig] = modules;
+
+      // As of Jan 2018, the autocomplete capability of the DataBC geocoder is available in Test, not in production.
+      // To handle this, two URLs are passed in the config object:
+      //    `url`: Production service to implement single line address search
+      //    `suggestUrl`: Test service to implement auto-complete suggestions
+      const url = options.url || 'https://apps.gov.bc.ca/pub/geocoder';
+      const suggestUrl = options.suggestUrl || 'https://test.apps.gov.bc.ca/pub/geocoder';
+
+      // Add known servers to the list of CORS enabled servers.
+      esriConfig.request.corsEnabledServers.push(url);
+      esriConfig.request.corsEnabledServers.push(suggestUrl);
+
+      // Return the new class
+      return (<any>Locator).createSubclass({
+        declaredClass: 'databc.tasks.Locator',
+        properties: {
+        },
+
+        // Find candidates for a single address specified in the address parameter.
+        // https://developers.arcgis.com/javascript/latest/api-reference/esri-tasks-Locator.html#addressToLocations
+        addressToLocations(params: __esri.LocatorAddressToLocationsParams,
+          requestOptions?: any): IPromise<__esri.AddressCandidate[]> {
+
+          const self: __esri.Locator = this;
+          const { outSpatialReference } = self;
+          const { address, maxLocations } = params;
+          const singleLineField = singleLineFieldName(options);
+
+          //  var address = {
+          //    "addressString": "525 Superior St, Victoria, BC"
+          //  };
+          const addressString: string = address[singleLineField];
+
+          const requestUrl = createRequestBuilder(url)
+            .setOutputFormat('json')
+            .setAddress(addressString)
+            .setAutoComplete(false)
+            .setMaxResults(maxLocations)
+            .setEcho(false)
+            .build();
+
+          // Request geojson data from remote server
+          return esriRequest(requestUrl, { responseType: 'json' })
+            .then((response: EsriResponse) => {
+              // The requested data
+              const geojson: GeocodeAddressResults = response.data;
+              const features = geojson.features || [];
+
+              // Parse server results into something that ArcGIS can understand...
+              return features.map(f => {
+                const json = this._parseAddressCandidate(f);
+                return AddressCandidate.fromJSON(json);
+              });
+            });
+        },
+
+        // Get character by character auto-complete suggestions.
+        // https://developers.arcgis.com/javascript/latest/api-reference/esri-tasks-Locator.html#suggestLocations
+        suggestLocations(params: LocatorSuggestLocationsParams, requestOptions?): IPromise<__esri.SuggestionResult[]> {
+          const self: __esri.Locator = this;
+          const { outSpatialReference } = self;
+          const { text, maxSuggestions } = params;
+
+          // Try `suggestUrl` if available, or fallback to `url`
+          const requestUrl = createRequestBuilder(suggestUrl)
+            .setOutputFormat('json')
+            .setAddress(text)
+            .setAutoComplete(true)
+            .setMaxResults(maxSuggestions)
+            .setEcho(false)
+            .build();
+
+          // Request geojson data from remote server
+          return esriRequest(requestUrl, { responseType: 'json' })
+            .then((response: EsriResponse) => {
+              // The requested data
+              const geojson: GeocodeAddressResults = response.data;
+              const features = geojson.features || [];
+
+              // Parse server results into something that ArcGIS can understand...
+              return features.map(f => this._parseSuggestionResult(f));
+            });
+        },
+
+        _parseAddressCandidate(result: Feature<Point>): __esri.AddressCandidateProperties {
+          // Ensure we got a proper Point geometry object
+          if (result.geometry.type !== 'Point') {
+            throw new Error('Invalid response. Location should be a Point');
+          }
+
+          // The coordinates order is [longitude, latitude]
+          // https://macwright.org/2015/03/23/geojson-second-bite#position
+          const [lng, lat] = result.geometry.coordinates;
+          const { fullAddress, score } = result.properties;
+
+          // Convert lat, long (WSG84) to Web Mercator coords
+          const [x, y] = webMercatorUtils.lngLatToXY(lng, lat);
+
+          return {
+            address: fullAddress as string,
+            score: score as number,
+            location: {  // autocasts as new Point()
+              x: x,
+              y: y,
+              spatialReference: SpatialReference.WebMercator
+            },
+            attributes: _.omit(result.properties, ['fullAddress', 'score'])
+          };
+        },
+
+        _parseSuggestionResult(result: Feature<Point>): __esri.SuggestionResult {
+          const { fullAddress } = result.properties;
+          return {
+            text: fullAddress as string,
+            magicKey: null,
+            isCollection: false
+          };
+        }
+      });
+    });
+}

--- a/src/app/map/widgets/widget-builder.spec.ts
+++ b/src/app/map/widgets/widget-builder.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { WidgetBuilder } from './widget-builder';
+
+describe('MapWidgetFactoryService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [WidgetBuilder]
+    });
+  });
+
+  it('should be created', inject([WidgetBuilder], (service: WidgetBuilder) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/map/widgets/widget-builder.ts
+++ b/src/app/map/widgets/widget-builder.ts
@@ -1,0 +1,132 @@
+import { Injectable, Optional } from '@angular/core';
+import { EsriLoaderService } from 'angular-esri-loader';
+
+import { MapConfigService } from '../config/map-config.service';
+import { createGeocoder, singleLineFieldName } from './support/geocoder';
+
+export interface ZoomWidgetProperties {
+  view: __esri.MapViewProperties;
+}
+
+export interface SearchWidgetProperties {
+  view: __esri.MapViewProperties;
+  featureLayer: __esri.FeatureLayer;
+  geocoder?: any;
+}
+
+/**
+ * Creates map widgets from a user-specified configuration
+ *
+ * @export
+ * @class WidgetBuilder
+ */
+@Injectable()
+export class WidgetBuilder {
+
+  constructor(
+    private config: MapConfigService,
+    private esriLoader: EsriLoaderService
+  ) { }
+
+  // TODO Add more overloads as more widgets are implemented - i.e. layer list, legend, etc
+  createWidget(type: 'zoom', props?: ZoomWidgetProperties): Promise<__esri.Zoom>
+  createWidget(type: 'search', props?: SearchWidgetProperties): Promise<__esri.Search>
+  createWidget(type: string, props?: any): Promise<any> {
+    switch (type) {
+      case 'zoom':
+        return this.createZoom(props);
+      case 'search':
+        return this.createSearch(props);
+      default:
+        return Promise.reject('Invalid type');
+    }
+  }
+
+  private createZoom(props: ZoomWidgetProperties): Promise<__esri.Zoom> {
+    return this.esriLoader.loadModules(['esri/widgets/Zoom'])
+      .then(([Zoom]: [__esri.ZoomConstructor]) => new Zoom({ view: props.view }));
+  }
+
+  private createSearch(props: SearchWidgetProperties): Promise<__esri.Search> {
+    const { view, featureLayer, geocoder } = props;
+    const addressFieldName = singleLineFieldName(geocoder);
+    let geoService: __esri.Locator;
+
+    // Get config settings for Location search (i.e. search for 'Fernie, BC') and layer search (i.e. search by mine name/description)
+    const locatorSource = this.getLocationSearchProps();
+    const layerSource = this.getLayerSearchProps();
+
+    return createGeocoder(this.esriLoader, geocoder)
+      .then(g => geoService = g)
+      .then(() => this.esriLoader.loadModules(['esri/widgets/Search']))
+      .then(([Search]: [__esri.SearchConstructor]) => {
+        // the locator task used to search. This is *required*
+        locatorSource.locator = geoService;
+        // the field name of the Single Line Address Field
+        locatorSource.singleLineFieldName = addressFieldName;
+
+        // the feature layer queried in the search. This is *required*
+        layerSource.featureLayer = featureLayer;
+
+        // Create map search widget
+        return new Search({
+          view: view,
+          allPlaceholder: 'Mine name or location',
+          searchAllEnabled: true,
+          sources: [locatorSource, layerSource]
+        });
+      });
+  }
+
+  // https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Search.html#LocatorSource
+  private getLocationSearchProps(): __esri.LocatorSource {
+    return <__esri.LocatorSource>{
+      name: 'Locations',
+      placeholder: 'Find location',
+      // Constricts search results to a specified country code. For example, `CA` for Canada
+      countryCode: 'CA',
+      maxResults: 3,
+      maxSuggestions: 6,
+      // whether to display suggestions as the user enters input text in the widget.
+      suggestionsEnabled: true,
+      // minimum number of characters required before querying for a suggestion
+      minSuggestCharacters: 1,
+      // whether to automatically navigate to the selected result once selected.
+      autoNavigate: true,
+      // the set zoom scale for the resulting search result. This scale is automatically honored.
+      zoomScale: 500000,
+      // whether to show a graphic on the map for the selected source using the `resultSymbol`
+      resultGraphicEnabled: false,
+      // whether to constrain the search results to the view's extent
+      withinViewEnabled: false,
+    };
+  }
+
+  // https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Search.html#FeatureLayerSource
+  private getLayerSearchProps(): __esri.FeatureLayerSource {
+    return <__esri.FeatureLayerSource>{
+      name: 'Major Mines',
+      placeholder: 'Find Mines in BC',
+      // results are displayed using this field. Defaults to the layer's `displayField` or the first string field.
+      displayField: 'name',
+      // specifies the fields in the feature layer to search
+      searchFields: ['name', 'description'],
+      // specifies the fields returned with the search results.
+      outFields: ['*'],
+      maxResults: 6,
+      maxSuggestions: 6,
+      // whether to display suggestions as the user enters input text in the widget.
+      suggestionsEnabled: true,
+      // minimum number of characters required before querying for a suggestion
+      minSuggestCharacters: 1,
+      // whether to automatically navigate to the selected result once selected.
+      autoNavigate: true,
+      // the set zoom scale for the resulting search result. This scale is automatically honored.
+      zoomScale: 500000,
+      // whether to show a graphic on the map for the selected source using the `resultSymbol`
+      resultGraphicEnabled: false,
+      // whether to constrain the search results to the view's extent
+      withinViewEnabled: false,
+    };
+  }
+}

--- a/src/assets/styles/components/esri-map.scss
+++ b/src/assets/styles/components/esri-map.scss
@@ -8,6 +8,7 @@
         color: $bg-dark-color;
 
         .esri-widget {
+            background: $map-popup-bg;
             font-family: $map-search-font-family;
             color: $map-popup-color;
         }
@@ -21,10 +22,19 @@
             margin: 0 !important;
             padding: 1rem;
             font-size: $map-popup-font-size;
+
+            a {
+                color: $bg-dark-color;
+
+                &:focus,
+                &:hover {
+                    color: $gold;
+                }
+            }
         }
 
         &__button {
-            color: $bg-dark-color; 
+            color: $bg-dark-color;
 
             &:active,
             &:focus,
@@ -106,7 +116,7 @@
                 font-size: $map-search-font-size;
             }
         }
-        
+
         &__warning-body {
             font-size: $map-search-font-size;
 
@@ -177,7 +187,7 @@
     list-style-type: none;
     padding-left: 0 !important;
 
-    li { 
+    li {
         @include flex-box();
         font-size: $map-popup-font-size !important;
 
@@ -200,7 +210,7 @@
         }
 
         .esri-search {
-            width: 30rem; 
+            width: 30rem;
 
             input {
                 width: 100%;

--- a/src/tsconfig.app.json
+++ b/src/tsconfig.app.json
@@ -5,7 +5,8 @@
     "module": "es2015",
     "baseUrl": "",
     "types": [
-      "arcgis-js-api"
+      "arcgis-js-api",
+      "geojson"
     ]
   },
   "exclude": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -158,6 +158,10 @@
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/@types/arcgis-js-api/-/arcgis-js-api-4.5.0.tgz#2471a6dd0ffa68011db7d4c709884c3baa245a3a"
 
+"@types/geojson@7946.0.0":
+  version "7946.0.0"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.0.tgz#e8bc74e8183d966455f82023f0c72e1072a952d0"
+
 "@types/jasmine@2.5.38":
   version "2.5.38"
   resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.5.38.tgz#a4379124c4921d4e21de54ec74669c9e9b356717"


### PR DESCRIPTION
* Refactor map code to use a `WidgetBuilder` factory
* Implement custom geocoder for DataBC
* Add new property `geocoder.type` to map configuration
* Allow creation of `arcgis` or `databc` geocoders based on map configuration
* Ensure map popups show with proper styling