### PR TITLE
EM-940-fix: EAO main documents not displaying in MMTI.

### DIFF
--- a/src/app/models/collection.ts
+++ b/src/app/models/collection.ts
@@ -72,7 +72,7 @@ export class Collection {
       // Set documents
       this.documents = [];
 
-      if (this.agency === 'eao' && collection.mainDocument) {
+      if (this.agency === 'eao' && collection.mainDocument && collection.mainDocument.document) {
         // EAO main documents are still returned as a single element
         this.documents.push({
           name : collection.mainDocument.document.displayName,


### PR DESCRIPTION
Apparently the documents returned by EAO (similarly to the ones returned by MEM) sometimes contain non-compliant data: the document object is null, and this makes the logic fail.

This additional check ensures that only documents with "good data" are processed, and that no error is thrown.