### PR TITLE
Relativized collection document links

### DIFF
--- a/src/app/map/main-map/main-map.component.spec.ts
+++ b/src/app/map/main-map/main-map.component.spec.ts
@@ -1,13 +1,17 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { WidgetBuilder } from '../widgets/widget-builder';
-
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { NgbModalBackdrop } from '@ng-bootstrap/ng-bootstrap/modal/modal-backdrop';
+import { NgbModalStack } from '@ng-bootstrap/ng-bootstrap/modal/modal-stack';
+import { NgbModalWindow } from '@ng-bootstrap/ng-bootstrap/modal/modal-window';
 import { EsriModuleProvider } from '../core/esri-module-provider';
-import { MapLoaderService } from '../core/map-loader.service';
-import { MainMapComponent } from './main-map.component';
 import { MapConfigService } from '../core/map-config.service';
-import { GeocoderSettings } from '../widgets/support/geocoder';
+import { MapLoaderService } from '../core/map-loader.service';
 import { EsriMapComponent } from '../esri-map/esri-map.component';
+import { WidgetBuilder } from '../widgets/widget-builder';
+import { MainMapComponent } from './main-map.component';
+import { CookieService } from 'ngx-cookie-service';
 
 describe('MainMapComponent', () => {
   let component: MainMapComponent;
@@ -29,20 +33,23 @@ describe('MainMapComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       providers: [
-        MapLoaderService,
-        WidgetBuilder,
+        CookieService,
         EsriModuleProvider,
+        MapLoaderService,
+        NgbModal,
+        NgbModalStack,
+        WidgetBuilder,
         { provide: MapConfigService, useValue: MockMapConfigService }
       ],
-      declarations: [
-        MainMapComponent,
-        EsriMapComponent
-      ],
-      imports: [
-        RouterTestingModule
-      ]
+      declarations: [EsriMapComponent, MainMapComponent, NgbModalBackdrop, NgbModalWindow],
+      imports: [RouterTestingModule]
     })
-    .compileComponents();
+      .overrideModule(BrowserDynamicTestingModule, {
+        set: {
+          entryComponents: [NgbModalBackdrop, NgbModalWindow]
+        }
+      })
+      .compileComponents();
   }));
 
   beforeEach(() => {
@@ -55,16 +62,22 @@ describe('MainMapComponent', () => {
       expect(MockMapConfigService.get()).toBeTruthy();
     });
     it('should set webMapProperties', () => {
-      expect(JSON.stringify(component.webMapProperties)).toBe(JSON.stringify(MockMapConfigService.get().mainMap.webmap));
+      expect(JSON.stringify(component.webMapProperties)).toBe(
+        JSON.stringify(MockMapConfigService.get().mainMap.webmap)
+      );
     });
     it('should set mapViewProperties', () => {
-      expect(JSON.stringify(component.mapViewProperties)).toBe(JSON.stringify(MockMapConfigService.get().mainMap.mapView));
+      expect(JSON.stringify(component.mapViewProperties)).toBe(
+        JSON.stringify(MockMapConfigService.get().mainMap.mapView)
+      );
     });
     it('should set popupProperties', () => {
       expect(JSON.stringify(component.popupProperties)).toBe(JSON.stringify(MockMapConfigService.get().mainMap.popup));
     });
     it('should set geocoderProperties', () => {
-      expect(JSON.stringify(component.geocoderProperties)).toBe(JSON.stringify(MockMapConfigService.get().mainMap.geocoder));
+      expect(JSON.stringify(component.geocoderProperties)).toBe(
+        JSON.stringify(MockMapConfigService.get().mainMap.geocoder)
+      );
     });
   });
 });

--- a/src/app/models/collection.ts
+++ b/src/app/models/collection.ts
@@ -13,7 +13,7 @@ export class Collection {
     date: Date;
   }[];
 
-  constructor(collection?: any) {
+  constructor(hostnameEPIC: string, hostnameMEM: string, collection?: any) {
     this._id         = collection && collection._id         || null;
     this.displayName = collection && collection.displayName || null;
     this.parentType  = collection && collection.parentType  || null;
@@ -76,7 +76,7 @@ export class Collection {
         // EAO main documents are still returned as a single element
         this.documents.push({
           name : collection.mainDocument.document.displayName,
-          ref  : this.getURL(collection.mainDocument.document._id),
+          ref  : this.getURL(collection.mainDocument.document._id, hostnameEPIC, hostnameMEM),
           date : collection.mainDocument.document.documentDate ? new Date(collection.mainDocument.document.documentDate) : null
         });
       } else if (collection.mainDocuments && collection.mainDocuments.length > 0) {
@@ -86,7 +86,7 @@ export class Collection {
         }).sort((a, b) => { return a.sortOrder - b.sortOrder; });
         mainDocs.forEach(item => this.documents.push({
           name : item.document.displayName,
-          ref  : this.getURL(item.document._id),
+          ref  : this.getURL(item.document._id, hostnameEPIC, hostnameMEM),
           date : item.document.documentDate ? new Date(item.document.documentDate) : null
         }));
       }
@@ -102,7 +102,7 @@ export class Collection {
           if (otherDoc.document) {
             this.documents.push({
               name : otherDoc.document.displayName,
-              ref  : this.getURL(otherDoc.document._id),
+              ref  : this.getURL(otherDoc.document._id, hostnameEPIC, hostnameMEM),
               date : otherDoc.document.documentDate ? new Date(otherDoc.document.documentDate) : null
             });
           }
@@ -111,9 +111,9 @@ export class Collection {
     }
   }
 
-  private getURL(id: string) {
-    const host = this.agency === 'eao' ? 'projects.eao.gov.bc.ca' : 'mines.empr.gov.bc.ca';
-    return `https://${host}/api/document/${id}/fetch`;
+  private getURL(id: string, hostnameEPIC: string, hostnameMEM: string) {
+    const host = this.agency === 'eao' ? hostnameEPIC : hostnameMEM;
+    return `${host}/api/document/${id}/fetch`;
   }
 }
 

--- a/src/app/projects/project-detail/documents/documents-tab-content.component.html
+++ b/src/app/projects/project-detail/documents/documents-tab-content.component.html
@@ -5,21 +5,21 @@
 
   <section class="doc-section">
     <div class="accordion inspections-list" role="tablist" aria-multiselectable="false">
-      <div class="accordion__collapse-item" *ngFor="let c of collections.items">
-        <div class="accordion__collapse-header" role="tab" id="heading-{{c._id}}">
-          <a class="accordion__collapse-header--column toggle collapsed" data-toggle="collapse" href="#collapse-{{c._id}}" aria-expanded="true" aria-controls="collapseOne">
+      <div class="accordion__collapse-item" *ngFor="let item of collections.items">
+        <div class="accordion__collapse-header" role="tab" id="heading-{{item._id}}">
+          <a class="accordion__collapse-header--column toggle collapsed" data-toggle="collapse" href="#collapse-{{item._id}}" aria-expanded="true" aria-controls="collapseOne">
             <i class="material-icons open-icon">add</i>
             <i class="material-icons close-icon">remove</i>
           </a>
-          <span class="accordion__collapse-header--column inspections-list__name-col">{{c.displayName}}</span>
-          <span class="accordion__collapse-header--column inspections-list__date-col">{{c.date | date:'yyyy-MM-dd'}}</span>
+          <span class="accordion__collapse-header--column inspections-list__name-col">{{item.displayName}}</span>
+          <span class="accordion__collapse-header--column inspections-list__date-col">{{item.date | date:'yyyy-MM-dd'}}</span>
         </div>
-        <div class="collapse" role="tabpanel" id="collapse-{{c._id}}" attr.aria-labelledby="heading-{{c._id}}">
+        <div class="collapse" role="tabpanel" id="collapse-{{item._id}}" attr.aria-labelledby="heading-{{item._id}}">
           <div class="accordion__collapse-body">
-            <div class="inspections-list__related-documents card" *ngIf="c.documents.length > 0">
+            <div class="inspections-list__related-documents card" *ngIf="item.documents.length > 0">
               <div class="card-header">Related Documents</div>
               <ul class="list-group">
-                <li class="list-group-item" *ngFor="let d of c.documents"><a href="{{d.ref}}" target="_blank">{{d.name}}</a></li>
+                <li class="list-group-item" *ngFor="let doc of item.documents"><a href="{{doc.ref}}" target="_blank">{{doc.name}}</a></li>
               </ul>
             </div>
           </div>

--- a/src/app/services/project.service.ts
+++ b/src/app/services/project.service.ts
@@ -90,7 +90,7 @@ export class ProjectService {
     const collections = res.text() ? res.json() : [];
 
     collections.forEach((collection, index) => {
-      collections[index] = new Collection(collection);
+      collections[index] = new Collection(this.api.hostnameEPIC, this.api.hostnameMEM, collection);
     });
     return collections;
   }


### PR DESCRIPTION
This should fix the links to download the documents so that they won't always point to the PROD instance, but will flex according to the environment currently in use (localhost/dev/test/prod).