### PR TITLE
remove apply of unused script

### DIFF
--- a/functional-tests/build.gradle
+++ b/functional-tests/build.gradle
@@ -23,8 +23,6 @@ ext {
   }
 }
 
-apply from: "gradle/osSpecificDownloads.gradle"
-
 repositories {
     mavenCentral()
 }


### PR DESCRIPTION
osSpecific downloads was removed, replaced by the erdi web driver binaries + browserstack