### PR TITLE
point reportDir at remoteChrome results

### DIFF
--- a/Jenkinsfile.dev
+++ b/Jenkinsfile.dev
@@ -207,7 +207,7 @@ podTemplate(label: browserStackPodLabel, name: browserStackPodLabel, serviceAcco
                         allowMissing: false,
                         alwaysLinkToLastBuild: false,
                         keepAll: true,
-                        reportDir: 'build/reports/tests/chromeHeadlessTest',
+                        reportDir: 'build/reports/tests/remoteChromeTest',
                         reportFiles: 'index.html',
                         reportName: "Full Test Report"
                     ])


### PR DESCRIPTION
functional tests run in browerstack, but build marked as failed due to bad report dir