### PR TITLE
NPRT-170: Add ID checks when adding collections

### DIFF
--- a/src/app/services/project.service.ts
+++ b/src/app/services/project.service.ts
@@ -92,15 +92,22 @@ export class ProjectService {
   }
 
   private addCollection(collectionsList: CollectionsList, collection: Collection) {
+    // ensure the collection hasn't already been added before adding again.
     switch (collection.parentType) {
       case 'Authorizations':
-        collectionsList.authorizations[collection.agency].add(collection);
+        if (!collectionsList.authorizations[collection.agency].items.some(existing => existing._id === collection._id)) {
+          collectionsList.authorizations[collection.agency].add(collection);
+        }
         break;
       case 'Compliance and Enforcement':
-        collectionsList.compliance.add(collection);
+        if (!collectionsList.compliance.items.some(existing => existing._id === collection._id)) {
+          collectionsList.compliance.add(collection);
+        }
         break;
       case 'Other':
-        collectionsList.documents.add(collection);
+        if (!collectionsList.documents.items.some(existing => existing._id === collection._id)) {
+          collectionsList.documents.add(collection);
+        }
         break;
     }
   }


### PR DESCRIPTION
Adding an ID check when adding collections to the project collection array to prevent the same collection from being added on multiple calls to the project collections.

See ticket [NRPT-170](https://bcmines.atlassian.net/browse/NRPT-170)