### PR TITLE
NRPT-205-2: Fix for Popup to use new layer name

### DIFF
--- a/src/app/map/leaflet-map/leaflet-map.component.ts
+++ b/src/app/map/leaflet-map/leaflet-map.component.ts
@@ -232,7 +232,7 @@ export class LeafletMapComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   identifyWmsLayers(e) {
-    if (this.map.hasLayer(this.overlays['Verified Mines'])) {
+    if (this.map.hasLayer(this.overlays['Major Mine Permitted Areas'])) {
       let bbox   = e.sourceTarget.getBounds().toBBoxString();
       let width  = e.sourceTarget.getSize().x;
       let height = e.sourceTarget.getSize().y;


### PR DESCRIPTION
The Major Mines popup could not display due to the layer rename (from a previous ticket). Updating the name so the layer can be identified again.

See ticket [NRPT-205](https://bcmines.atlassian.net/browse/NRPT-205)