### PR TITLE
NRPT-243: Add temporary setting for v2 to nrpti test

### DIFF
--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -41,7 +41,11 @@ export class Api {
         hostnameNRPTI  = 'https://nrpti-test.pathfinder.gov.bc.ca';
         env = 'test';
         break;
-
+      case 'www-mem-mmt-dev-v2.pathfinder.gov.bc.ca':
+        // Test for v2 Feature Branch (temporary)
+        hostnameNRPTI  = 'https://nrpti-test.pathfinder.gov.bc.ca';
+        env = 'test';
+        break;
       default:
         // Prod
         hostnameNRPTI  = 'https://nrpti-prod.pathfinder.gov.bc.ca';


### PR DESCRIPTION
Adding an additional temporary setting for BCMI v2 feature branch to NRPTI test to prevent defaulting to prod

See ticket [NRPT-243](https://bcmines.atlassian.net/browse/NRPT-243)