### PR TITLE
NRPT-302: Show collections from NRPTI

### DIFF
--- a/src/app/projects/project-detail/authorizations/authorizations-tab-content.component.html
+++ b/src/app/projects/project-detail/authorizations/authorizations-tab-content.component.html
@@ -64,17 +64,17 @@
     </div>
   </section>
 
-  <section class="auth-section" *ngIf="collections.mem.length > 0">
+  <section class="auth-section" *ngIf="collections.empr.length > 0">
     <h3>Mines Act <span>Ministry of Energy, Mines and Petroleum Resources</span></h3>
     <div class="accordion authorizations-list" id="authorization-MEM" role="tablist" aria-multiselectable="false">
-      <div class="accordion__collapse-item" *ngFor="let c of collections.mem.items">
+      <div class="accordion__collapse-item" *ngFor="let c of collections.empr.items">
         <div class="accordion__collapse-header" role="tab" id="heading-{{c._id}}">
           <a class="accordion__collapse-header--column toggle collapsed" data-ng-if="c.documents" data-toggle="collapse" href="#collapse-{{c._id}}"
             aria-expanded="true" aria-controls="collapseOne">
             <i class="material-icons open-icon">add</i>
             <i class="material-icons close-icon">remove</i>
           </a>
-          <span class="accordion__collapse-header--column authorizations-list__name-col">{{project.memPermitID}} - {{c.displayName}}</span>
+          <span class="accordion__collapse-header--column authorizations-list__name-col">{{project.permitNumber}} - {{c.displayName}}</span>
           <span class="accordion__collapse-header--column authorizations-list__date-col">
             <span>Permit {{c.status}}</span> -
             <span>{{c.date | date:'yyyy-MM-dd'}}</span>

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -4,8 +4,6 @@ import { HttpClient } from '@angular/common/http';
 import { Params } from '@angular/router';
 import { URLConstants } from 'app/shared/constants';
 
-
-
 @Injectable()
 export class Api {
   pathNRPTI: string;
@@ -86,18 +84,18 @@ export class Api {
     return this.getNRPTI(`public/search?dataset=MineBCMI&keywords=${nameFromCode}&pageNum=0&pageSize=1&sortBy=-score`);
   }
 
-  // may be ignorable if fetched as a populate=true from projectByCode
-  getProjectCollections(projectCode: string) {
-    let nameFromCode = projectCode
-                        .toLowerCase() // should be lowercase already, but just in case
-                        .split('-')
-                        .map(name => name.charAt(0).toUpperCase() + name.slice(1))
-                        .join(' ');
-
-    return this.getNRPTI(`public/search?dataset=MineBCMI&keywords=${nameFromCode}&pageNum=0&pageSize=1&sortBy=-score&populate=true`);
+  getProjectCollections(projectId: string) {
+    return this.getNRPTI(`public/search?dataset=CollectionBCMI&pageNum=0&pageSize=1000&sortBy=-dateAdded&and[project]=${projectId}&fields=&populate=true`);
   }
 
+  getCollectionRecord(recordId: string) {
+    return this.getNRPTI(`public/search?dataset=Item&_id=${recordId}&populate=true`);
+  }
   // Proponents
+
+  getDocument(documentId: string) {
+    return this.getNRPTI(`public/search?dataset=Item&_schemaName=Document&_id=${documentId}&populate=true`);
+  }
 
   getProponents() {
     return new Observable(); // this.getNRPTI('organization');
@@ -115,7 +113,6 @@ export class Api {
 
   handleError(error: any) {
     const reason = error.message ? error.message : (error.status ? `${error.status} - ${error.statusText}` : 'Server error');
-    console.log(reason);
     return observableThrowError(reason);
   }
 

--- a/src/app/services/project.service.ts
+++ b/src/app/services/project.service.ts
@@ -48,23 +48,67 @@ export class ProjectService {
   }
 
   private getCollections() {
-    return this.api.getProjectCollections(this.project.name.replace(/\W+/g, '-').toLowerCase()).pipe(
-      map((res: any) => this.processCollections(res)),
-      map((collections: any[]) => {
+    return this.api.getProjectCollections(this.project._id).pipe(
+      map((res: any) => this.processCollections(res && res[0] && res[0].searchResults ? res[0].searchResults : null)),
+      map(async (collections: any[]) => {
         // Push them into the project
-        collections.forEach(collection => {
+        await this.loadCollectionRecords(collections);
+
+        collections.filter(c => c.documents.length > 0).forEach(collection => {
           this.addCollection(this.project.collections, collection);
         });
-      }));
+      })
+    );
   }
 
   private processCollections(res: any[]): any[] {
     const collections = res ? res : [];
 
     collections.forEach((collection, index) => {
-      collections[index] = new Collection(this.api.hostnameNRPTI, this.api.hostnameNRPTI, collection);
+      collections[index] = new Collection(collection);
     });
+
     return collections;
+  }
+
+  private async loadCollectionRecords(collectionsList: any[]) {
+    for (const collection of collectionsList) {
+      for (const recordId of collection.records) {
+        // fetch the record from NRPTI
+        const recordResult = await this.api.getCollectionRecord(recordId).toPromise();
+        const loadedRecord = recordResult && recordResult['length'] > 0 ? recordResult[0] : null;
+        // create the record only if this is published to bcmi (either by flag or by flavour) and actually has a document attached
+        // && (loadedRecord.isBcmiPublished || loadedRecord.flavours.find(f => f._schemaName.endsWith('BCMI') && f.read.includes('public')))
+        if (loadedRecord) {
+          // get the loaded records document ref URL
+          let document = null;
+          // permit/permitBCMI has amendmentDocument rather than a documents array
+          // this is not populate by populate=true
+          if (loadedRecord._schemaName === 'Permit') {
+            const bcmiFlavour = loadedRecord.flavours.find(f => f._schemaName.endsWith('BCMI'));
+            if (bcmiFlavour) {
+              let documentId = bcmiFlavour.amendmentDocument.documentId;
+              const docResult = await this.api.getDocument(documentId).toPromise();
+              document = docResult && docResult['length'] > 0 ? docResult[0] : null;
+            }
+          } else {
+            // has the 'documents' array. BCMI versions should only have one doc so should we assume
+            // the first doc, or just create a row for each, which would most likely be only one anyway?
+            document = loadedRecord.documents && loadedRecord.documents.length > 0 ? loadedRecord.documents[0] : null;
+          }
+
+          if (document) {
+            collection.documents.push({
+              name : loadedRecord['recordName'] || '-',
+              ref  : document.url,
+              date : loadedRecord['date'] || '-'
+            });
+          }
+        }
+      }
+    }
+
+    return collectionsList;
   }
 
   private addCollection(collectionsList: CollectionsList, collection: Collection) {

--- a/src/app/services/project.service.ts
+++ b/src/app/services/project.service.ts
@@ -81,27 +81,20 @@ export class ProjectService {
         if (loadedRecord && (loadedRecord.isBcmiPublished || loadedRecord.flavours.find(f => f._schemaName.endsWith('BCMI') && f.read.includes('public')))) {
           // get the loaded records document ref URL
           let document = null;
-          // permit/permitBCMI has amendmentDocument rather than a documents array
-          // this is not populate by populate=true
-          if (loadedRecord._schemaName === 'Permit') {
-            const bcmiFlavour = loadedRecord.flavours.find(f => f._schemaName.endsWith('BCMI'));
-            if (bcmiFlavour) {
-              let documentId = bcmiFlavour.amendmentDocument.documentId;
-              const docResult = await this.api.getDocument(documentId).toPromise();
-              document = docResult && docResult['length'] > 0 ? docResult[0] : null;
-            }
-          } else {
-            // has the 'documents' array. BCMI versions should only have one doc so should we assume
+          // Grab the documents. If the object doesn't have a document attribute
+          // or the document array is empty, we should not add a document
+          if (Object.prototype.hasOwnProperty.call(document, 'documents')) {
+            // BCMI versions should only have one doc so should we assume
             // the first doc, or just create a row for each, which would most likely be only one anyway?
             document = loadedRecord.documents && loadedRecord.documents.length > 0 ? loadedRecord.documents[0] : null;
-          }
 
-          if (document) {
-            collection.documents.push({
-              name : loadedRecord['recordName'] || '-',
-              ref  : document.url,
-              date : loadedRecord['date'] || '-'
-            });
+            if (document) {
+              collection.documents.push({
+                name : loadedRecord['recordName'] || '-',
+                ref  : document.url,
+                date : loadedRecord['date'] || '-'
+              });
+            }
           }
         }
       }

--- a/src/app/services/project.service.ts
+++ b/src/app/services/project.service.ts
@@ -94,6 +94,7 @@ export class ProjectService {
                 date : loadedRecord['date'] || '-'
               });
             }
+          }
         }
       }
     }

--- a/src/app/services/project.service.ts
+++ b/src/app/services/project.service.ts
@@ -80,13 +80,12 @@ export class ProjectService {
         // create the record only if this is published to bcmi (either by flag or by flavour) and actually has a document attached
         if (loadedRecord && (loadedRecord.isBcmiPublished || loadedRecord.flavours.find(f => f._schemaName.endsWith('BCMI') && f.read.includes('public')))) {
           // get the loaded records document ref URL
-          let document = null;
           // Grab the documents. If the object doesn't have a document attribute
           // or the document array is empty, we should not add a document
-          if (Object.prototype.hasOwnProperty.call(document, 'documents')) {
+          if (Object.prototype.hasOwnProperty.call(loadedRecord, 'documents')) {
             // BCMI versions should only have one doc so should we assume
             // the first doc, or just create a row for each, which would most likely be only one anyway?
-            document = loadedRecord.documents && loadedRecord.documents.length > 0 ? loadedRecord.documents[0] : null;
+            let document = loadedRecord.documents && loadedRecord.documents.length > 0 ? loadedRecord.documents[0] : null;
 
             if (document) {
               collection.documents.push({
@@ -95,7 +94,6 @@ export class ProjectService {
                 date : loadedRecord['date'] || '-'
               });
             }
-          }
         }
       }
     }

--- a/src/app/services/project.service.ts
+++ b/src/app/services/project.service.ts
@@ -78,8 +78,7 @@ export class ProjectService {
         const recordResult = await this.api.getCollectionRecord(recordId).toPromise();
         const loadedRecord = recordResult && recordResult['length'] > 0 ? recordResult[0] : null;
         // create the record only if this is published to bcmi (either by flag or by flavour) and actually has a document attached
-        // && (loadedRecord.isBcmiPublished || loadedRecord.flavours.find(f => f._schemaName.endsWith('BCMI') && f.read.includes('public')))
-        if (loadedRecord) {
+        if (loadedRecord && (loadedRecord.isBcmiPublished || loadedRecord.flavours.find(f => f._schemaName.endsWith('BCMI') && f.read.includes('public')))) {
           // get the loaded records document ref URL
           let document = null;
           // permit/permitBCMI has amendmentDocument rather than a documents array


### PR DESCRIPTION
Adding functionality to the mines detail page to display collections and records from NRPTI.

Note: Relies on changes to the NRPTI API from [PR 530](https://github.com/bcgov/NRPTI/pull/530)

See tickets [NRPT-302](https://bcmines.atlassian.net/browse/NRPT-302), [NRPT-303](https://bcmines.atlassian.net/browse/NRPT-303), and [NRPT-304](https://bcmines.atlassian.net/browse/NRPT-304)