### PR TITLE
NRPT-306: Adds information modal

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -18,7 +18,8 @@
             "polyfills": "src/polyfills.ts",
             "assets": [
               "src/assets",
-              "src/favicon.ico"
+              "src/favicon.ico",
+              "src/env.js"
             ],
             "styles": [
               "node_modules/bootstrap/dist/css/bootstrap.min.css",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -206,3 +206,17 @@
 	[pageScrollDuration]="800">
 	<i class="material-icons">arrow_upward</i>
 </a>
+
+<!-- Information Modal -->
+<ng-template #informationModal>
+	<div class="modal-header">
+		<h5 class="modal-title" id="informationModalHeader">{{ modalMessage.title || 'Information'}}</h5>
+		<button type="button" class="close" (click)="dismiss()" aria-label="Close">
+			<span aria-hidden="true">&times;</span>
+		</button>
+	</div>
+	<div class="modal-body" [innerHtml]="modalMessage.description"></div>
+	<div class="modal-footer">
+		<button type="button" class="btn content-btn-alt" (click)="dismiss()">OK</button>
+	</div>
+</ng-template>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -3,6 +3,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { NgxPageScrollModule } from 'ngx-page-scroll';
 import { CookieService } from 'ngx-cookie-service';
 import { Api } from 'app/services/api';
+import { ConfigService } from 'app/services/config.service';
 import { HttpClientModule } from '@angular/common/http';
 import { AppComponent } from 'app/app.component';
 
@@ -11,7 +12,8 @@ describe('AppComponent', () => {
     TestBed.configureTestingModule({
       providers: [
         CookieService,
-        Api
+        Api,
+        ConfigService
       ],
       declarations: [
         AppComponent

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,8 +1,9 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, AfterViewInit, ViewChild, ElementRef } from '@angular/core';
 import { CookieService } from 'ngx-cookie-service';
+import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 
 import { DocumentService } from 'app/services/document.service';
-
+import { ConfigService } from 'app/services/config.service';
 import { Api } from 'app/services/api';
 
 @Component({
@@ -11,19 +12,76 @@ import { Api } from 'app/services/api';
   styleUrls: ['./app.component.scss'],
   providers: [DocumentService]
 })
-export class AppComponent implements OnInit {
+export class AppComponent implements OnInit, AfterViewInit {
+  @ViewChild('informationModal') modal: ElementRef;
+  modalRef: NgbModalRef;
+
   loggedIn: String;
   hostname: String;
+  modalMessage: any;
+
   constructor(private cookieService: CookieService,
-              private api: Api) {
+              private api: Api,
+              private modalService: NgbModal,
+              private configService: ConfigService) {
     // Used for sharing links.
     this.hostname = this.api.hostnameNRPTI;
   }
 
   ngOnInit() {
     this.loggedIn = this.cookieService.get('loggedIn');
+    this.modalMessage = this.configService.config['COMMUNICATIONS'];
 
-      document.body.scrollTop = 0;
-      document.documentElement.scrollTop = 0;
+    document.body.scrollTop = 0;
+    document.documentElement.scrollTop = 0;
+  }
+
+  ngAfterViewInit() {
+    this.openModalIfNew();
+  }
+
+  openModalIfNew() {
+    if (this.modalMessage && this.modalMessage.description && this.datesAreValid() && this.messageIsNew()) {
+      this.modalRef = this.modalService.open(this.modal, { keyboard: false, backdrop: 'static' });
+    }
+  }
+
+  datesAreValid() {
+    if (!this.modalMessage.startDate || !this.modalMessage.endDate) {
+      return false;
+    }
+
+    const today = new Date();
+
+    if ((this.modalMessage.startDate <= today) && (this.modalMessage.endDate > today)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  messageIsNew() {
+    const cookie = this.cookieService.get('informationModalRead');
+
+    // If the message has never been dismissed then treat it as new.
+    if (!cookie) {
+      return true;
+    }
+
+    // The it is a new message then remove the cookie and display it.
+    if (cookie !== this.modalMessage._id) {
+      this.cookieService.delete('informationModalRead');
+      return true;
+    }
+
+    return false;
+  }
+
+  dismiss() {
+    const expirationDate = new Date();
+    expirationDate.setFullYear(expirationDate.getFullYear() + 1);
+
+    this.cookieService.set('informationModalRead', this.modalMessage._id, expirationDate);
+    this.modalRef.dismiss();
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,5 @@
 import { BrowserModule } from '@angular/platform-browser';
-import { NgModule } from '@angular/core';
+import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
@@ -21,6 +21,8 @@ import { TailingsManagementComponent } from 'app/static-pages/tailings-managemen
 import { ReclamationComponent } from 'app/static-pages/reclamation/reclamation.component';
 import { NotFoundComponent } from 'app/not-found/not-found.component';
 import { ProponentService } from 'app/services/proponent.service';
+import { ConfigService } from 'app/services/config.service';
+import { GeocoderService } from 'app/services/geocoder.service';
 
 // feature modules
 import { MapModule } from 'app/map/map.module';
@@ -30,6 +32,10 @@ import { SharedModule } from 'app/shared/shared.module';
 import { TagInputModule } from 'ngx-chips';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { EnforcementActionsComponent } from 'app/static-pages/enforcement-actions/enforcement-actions.component';
+
+export function initConfig(configService: ConfigService) {
+  return () => configService.init();
+}
 
 @NgModule({
   declarations: [
@@ -66,7 +72,18 @@ import { EnforcementActionsComponent } from 'app/static-pages/enforcement-action
     MapModule,
     SharedModule
   ],
-  providers: [ProponentService, CookieService],
+  providers: [
+    {
+      provide: APP_INITIALIZER,
+      useFactory: initConfig,
+      multi: true,
+      deps: [ConfigService]
+    },
+    ProponentService,
+    CookieService,
+    ConfigService,
+    GeocoderService
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ProjectService } from 'app/services/project.service';
+import { ConfigService } from 'app/services/config.service';
 import { Api } from 'app/services/api';
 import { HttpClientModule } from '@angular/common/http';
 import { HomeComponent } from 'app/home/home.component';
@@ -21,7 +22,7 @@ describe('HomeComponent', () => {
     };
     TestBed.configureTestingModule({
       declarations: [HomeComponent],
-      providers: [{ provide: ProjectService, useValue: ProjectServiceStub }, Api],
+      providers: [{ provide: ProjectService, useValue: ProjectServiceStub }, Api, ConfigService],
       imports: [RouterTestingModule, HttpClientModule]
     }).compileComponents();
   }));

--- a/src/app/map/main-map/main-map.component.spec.ts
+++ b/src/app/map/main-map/main-map.component.spec.ts
@@ -14,6 +14,7 @@ import { LeafletMapComponent } from '../leaflet-map/leaflet-map.component';
 import { TestConstants } from 'app/shared/test-constants';
 import { GeocoderService } from 'app/services/geocoder.service';
 import { Api } from 'app/services/api';
+import { ConfigService } from 'app/services/config.service';
 
 @Component({
   selector: 'leaflet-map',
@@ -61,7 +62,8 @@ describe('MainMapComponent', () => {
         HttpHandler,
         { provide: ProjectService, useValue: ProjectServiceStub },
         GeocoderService,
-        Api
+        Api,
+        ConfigService
       ],
       declarations: [
         MainMapComponent,

--- a/src/app/map/search/search.component.spec.ts
+++ b/src/app/map/search/search.component.spec.ts
@@ -8,6 +8,7 @@ import { SearchComponent } from 'app/map/search/search.component';
 import { TestConstants } from 'app/shared/test-constants';
 import { GeocoderService } from 'app/services/geocoder.service';
 import { Api } from 'app/services/api';
+import { ConfigService } from 'app/services/config.service';
 import { HttpClient, HttpHandler } from '@angular/common/http';
 
 
@@ -32,6 +33,7 @@ describe('SearchComponent', () => {
       providers: [
         {provide: GeocoderService, useValue: GeocoderServiceStub },
         Api,
+        ConfigService,
         HttpClient,
         HttpHandler
       ],

--- a/src/app/projects/project-detail-resolver.service.spec.ts
+++ b/src/app/projects/project-detail-resolver.service.spec.ts
@@ -4,6 +4,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { ProjectDetailResolver } from 'app/projects/project-detail-resolver.service';
 import { ProjectService } from 'app/services/project.service';
 import { Api } from 'app/services/api';
+import { ConfigService } from 'app/services/config.service';
 import { HttpClientModule } from '@angular/common/http';
 
 describe('ProjectDetailResolverService', () => {
@@ -12,7 +13,8 @@ describe('ProjectDetailResolverService', () => {
       providers: [
         ProjectService,
         ProjectDetailResolver,
-        Api
+        Api,
+        ConfigService
       ],
       declarations: [],
       imports: [

--- a/src/app/projects/project-detail/project-detail.component.spec.ts
+++ b/src/app/projects/project-detail/project-detail.component.spec.ts
@@ -10,6 +10,7 @@ import { LeafletMapComponent } from 'app/map/leaflet-map/leaflet-map.component';
 import { OrderByPipe } from 'app/pipes/filters/order-by.pipe';
 import { SiteActivitiesComponent } from 'app/projects/site-activities/site-activities.component';
 import { Api } from 'app/services/api';
+import { ConfigService } from 'app/services/config.service';
 
 describe('ProjectDetailComponent', () => {
   let component: ProjectDetailComponent;
@@ -62,7 +63,8 @@ describe('ProjectDetailComponent', () => {
           { provide: ActivatedRoute, useValue: ActivatedRouteStub },
           { provide: Router, useValue: router },
           LeafletMapComponent,
-          { provide: ProjectService, useValue: ProjectServiceStub }
+          { provide: ProjectService, useValue: ProjectServiceStub },
+          ConfigService
         ],
         declarations: [
           ProjectDetailComponent,

--- a/src/app/projects/project-list/project-list.component.spec.ts
+++ b/src/app/projects/project-list/project-list.component.spec.ts
@@ -13,6 +13,7 @@ import { OperatorFilterPipe } from 'app/pipes/operator-filter.pipe';
 import { ObjectFilterPipe } from 'app/pipes/object-filter.pipe';
 import { ProjectService } from 'app/services/project.service';
 import { Api } from 'app/services/api';
+import { ConfigService } from 'app/services/config.service';
 
 describe('ProjectComponent', () => {
   let component: ProjectListComponent;
@@ -32,7 +33,8 @@ describe('ProjectComponent', () => {
     TestBed.configureTestingModule({
       providers: [
         {provide: ProjectService, useValue: ProjectServiceStub},
-        Api
+        Api,
+        ConfigService,
       ],
       declarations: [
         ProjectListComponent,

--- a/src/app/services/api.spec.ts
+++ b/src/app/services/api.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed, inject } from '@angular/core/testing';
 import { HttpClientModule } from '@angular/common/http';
 import { Api } from 'app/services/api';
+import { ConfigService } from 'app/services/config.service';
 
 describe('Api', () => {
   beforeEach(() => {
@@ -8,46 +9,7 @@ describe('Api', () => {
 
     TestBed.configureTestingModule({
       imports: [HttpClientModule],
-      providers: [Api]
-    });
-  });
-
-  describe('getHostName()', () => {
-    describe('localhost', () => {
-      it(
-        'should return http://localhost:3000',
-        inject([Api], (api) => {
-          expect(api.getHostName('localhost').hostnameMEM).toBe('http://localhost:3000');
-        })
-      );
-    });
-    describe('www-mem-mmt-dev.pathfinder.gov.bc.ca', () => {
-      it(
-        'should return http://localhost:4000',
-        inject([Api], (api) => {
-          expect(api.getHostName('www-mem-mmt-dev.pathfinder.gov.bc.ca').hostnameMEM).toBe(
-            'https://nrpti-dev.pathfinder.gov.bc.ca'
-          );
-        })
-      );
-    });
-    describe('www-mem-mmt-test.pathfinder.gov.bc.ca', () => {
-      it(
-        'should return https://mem-mmt-test.pathfinder.gov.bc.ca',
-        inject([Api], (api) => {
-          expect(api.getHostName('www-mem-mmt-test.pathfinder.gov.bc.ca').hostnameMEM).toBe(
-            'https://nrpti-test.pathfinder.gov.bc.ca'
-          );
-        })
-      );
-    });
-    describe('http://mines.nrs.gov.bc.ca/', () => {
-      it(
-        'should return https://mem-mmt-test.pathfinder.gov.bc.ca',
-        inject([Api], (api) => {
-          expect(api.getHostName('mines.nrs.gov.bc.ca/').hostnameMEM).toBe('https://nrpti-prod.pathfinder.gov.bc.ca');
-        })
-      );
+      providers: [Api, ConfigService]
     });
   });
 

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -2,7 +2,7 @@ import {throwError as observableThrowError, Observable } from 'rxjs';
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Params } from '@angular/router';
-import { URLConstants } from 'app/shared/constants';
+import { ConfigService } from 'app/services/config.service';
 
 @Injectable()
 export class Api {
@@ -11,57 +11,19 @@ export class Api {
   params: Params;
   env: 'local' | 'dev' | 'test' | 'prod';
 
-  constructor(private http: HttpClient) {
-    const host = this.getHostName(window.location.hostname);
-    this.hostnameNRPTI = host.hostnameMEM;
-    this.env = host.env;
-    this.pathNRPTI  = this.getNRPTIPath(this.hostnameNRPTI);
-  }
-
-  getHostName(hostname: string) {
-    let hostnameNRPTI: string;
-    let env: 'local' | 'dev' | 'test' | 'prod';
-
-    switch (hostname) {
-      case 'localhost':
-        // Local
-        hostnameNRPTI  =   URLConstants.localApiHostname;
-        env = 'local';
-        break;
-
-      case 'www-mem-mmt-dev.pathfinder.gov.bc.ca':
-        // Dev
-        hostnameNRPTI  = URLConstants.devApiHostname;
-        env = 'dev';
-        break;
-
-      case 'www-mem-mmt-test.pathfinder.gov.bc.ca':
-        // Test
-        hostnameNRPTI  = URLConstants.testApiHostname;
-        env = 'test';
-        break;
-      case 'www-mem-mmt-dev-v2.pathfinder.gov.bc.ca':
-        // Test for v2 Feature Branch (temporary)
-        hostnameNRPTI  = URLConstants.testApiHostname;
-        env = 'test';
-        break;
-      default:
-        // Prod
-        hostnameNRPTI  = URLConstants.prodApiHostname;
-        env = 'prod';
-    }
-
-    return { hostnameMEM: hostnameNRPTI, env };
-  }
-
-  getNRPTIPath(hostnameMEM) {
-    return `${ hostnameMEM }/api`;
+  constructor(
+    private http: HttpClient,
+    private configService: ConfigService
+    ) {
+    this.hostnameNRPTI = this.configService.config['API_LOCATION'];
+    this.env = this.configService.config['ENVIRONMENT'];
+    this.pathNRPTI = this.configService.config['API_LOCATION'] + this.configService.config['API_PUBLIC_PATH'];
   }
 
   // Projects
 
   getProjects() {
-    return this.getNRPTI(`public/search?dataset=MineBCMI&pageNum=0&pageSize=1000&sortBy=+name`);
+    return this.getNRPTI(`search?dataset=MineBCMI&pageNum=0&pageSize=1000&sortBy=+name`);
   }
 
 // get by id? `record/${model}/${recordId}`
@@ -81,24 +43,24 @@ export class Api {
                         .map(name => name.charAt(0).toUpperCase() + name.slice(1))
                         .join(' ');
 
-    return this.getNRPTI(`public/search?dataset=MineBCMI&keywords=${nameFromCode}&pageNum=0&pageSize=1&sortBy=-score`);
+    return this.getNRPTI(`search?dataset=MineBCMI&keywords=${nameFromCode}&pageNum=0&pageSize=1&sortBy=-score`);
   }
 
   getProjectCollections(projectId: string) {
-    return this.getNRPTI(`public/search?dataset=CollectionBCMI&pageNum=0&pageSize=1000&sortBy=-dateAdded&and[project]=${projectId}&fields=&populate=true`);
+    return this.getNRPTI(`search?dataset=CollectionBCMI&pageNum=0&pageSize=1000&sortBy=-dateAdded&and[project]=${projectId}&fields=&populate=true`);
   }
 
   getCollectionRecord(recordId: string) {
-    return this.getNRPTI(`public/search?dataset=Item&_id=${recordId}&populate=true`);
+    return this.getNRPTI(`search?dataset=Item&_id=${recordId}&populate=true`);
   }
 
   getCollectionDocuments(collectionId: string) {
-    return this.getNRPTI(`public/search?dataset=CollectionDocuments&_id=${collectionId}`);
+    return this.getNRPTI(`search?dataset=CollectionDocuments&_id=${collectionId}`);
   }
   // Proponents
 
   getDocument(documentId: string) {
-    return this.getNRPTI(`public/search?dataset=Item&_schemaName=Document&_id=${documentId}&populate=true`);
+    return this.getNRPTI(`search?dataset=Item&_schemaName=Document&_id=${documentId}&populate=true`);
   }
 
   getProponents() {
@@ -111,8 +73,8 @@ export class Api {
     return this.get(this.pathNRPTI, apiRoute, options);
   }
 
-  lookupAddress(requestUrl: string, options?: Object) {
-    return this.http.get(requestUrl, options || []);
+  lookupAddress(addressUrl: string, options?: Object) {
+    return this.get(this.hostnameNRPTI, addressUrl, options || []);
   }
 
   handleError(error: any) {

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { tap, mapTo } from 'rxjs/operators';
+
+@Injectable()
+export class ConfigService {
+  // defaults
+  private configuration = { };
+
+  constructor(private httpClient: HttpClient) { }
+
+  /**
+   * Initialize the Config Service.  Get configuration data from front-end build, or back-end if nginx
+   * is configured to pass the /config endpoint to a dynamic service that returns JSON.
+   */
+  async init() {
+    try {
+      this.configuration = await this.httpClient.get('api/config/bcmi')
+        .pipe(
+          tap((configuration: any) => this.configuration = configuration),
+          mapTo(undefined),
+        ).toPromise();
+
+      if (this.configuration['debugMode']) {
+        console.log('Configuration:', this.configuration);
+      }
+    } catch (e) {
+      // Not configured
+      console.log('Error getting configuration:', e);
+      this.configuration = window['__env'];
+
+      if (this.configuration['debugMode']) {
+        console.log('Configuration:', this.configuration);
+      }
+    }
+
+    return Promise.resolve();
+  }
+
+  get config(): any {
+    return this.configuration;
+  }
+}

--- a/src/app/services/document.service.spec.ts
+++ b/src/app/services/document.service.spec.ts
@@ -3,12 +3,14 @@ import { Api } from 'app/services/api';
 import { HttpClientModule } from '@angular/common/http';
 
 import { DocumentService } from 'app/services/document.service';
+import { ConfigService } from 'app/services/config.service';
 
 describe('DocumentService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
         DocumentService,
+        ConfigService,
         Api
       ],
       declarations: [],

--- a/src/app/services/geocoder-api.ts
+++ b/src/app/services/geocoder-api.ts
@@ -1,8 +1,5 @@
-import { URLConstants } from 'app/shared/constants';
-
 class RequestBuilder {
   // required
-  private _baseUrl: string;
   private _outputFormat: string;
   private _addressString: string;
 
@@ -22,7 +19,6 @@ class RequestBuilder {
   private _maxDistance: number;
 
   constructor() {
-    this._baseUrl = URLConstants.geocoder_api;
     this._outputFormat = 'json';
     this._outputSRS = 4326;  // --> WGS84 (default map projection)
   }
@@ -160,7 +156,7 @@ class RequestBuilder {
    * @returns the URL used to get the results of the geocode request
    */
   build(): string {
-    let url = this._baseUrl + '/addresses';
+    let url = '/addresses';
     if (this._outputFormat) {
       url += '.' + encodeURIComponent(this._outputFormat);
     }

--- a/src/app/shared/constants.ts
+++ b/src/app/shared/constants.ts
@@ -1,8 +1,0 @@
-export class URLConstants {
-  public static readonly geocoder_api = 'https://geocoder.api.gov.bc.ca';
-  public static readonly localApiHostname = 'http://localhost:3000';
-  public static readonly devApiHostname = 'https://nrpti-dev.pathfinder.gov.bc.ca';
-  public static readonly testApiHostname = 'https://nrpti-test.pathfinder.gov.bc.ca';
-  public static readonly prodApiHostname = 'https://nrpti-prod.pathfinder.gov.bc.ca';
-
-}

--- a/src/env.js
+++ b/src/env.js
@@ -1,0 +1,17 @@
+(function (window) {
+  window.__env = window.__env || {};
+
+  // Ideally in our app we have a wrapper around our logger class in the angular front ends to
+  // turn on/off the console.log's
+  window.__env.enableDebug = false;
+
+  // Environment name
+  window.__env.ENVIRONMENT = 'local';  // local | dev | test | prod
+
+  window.__env.API_LOCATION = 'http://localhost:3000';
+  window.__env.API_PATH = '/api';
+  window.__env.API_PUBLIC_PATH = '/api/public';
+
+  // Add any feature-toggles
+  // window.__env.coolFeatureActive = false;
+}(this));

--- a/src/index.html
+++ b/src/index.html
@@ -8,6 +8,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 
+  <!-- Environment var -->
+  <script src="env.js"></script>
+
   <!-- Snowplow starts plowing - Standalone vA.2.10.2 -->
   <script type="text/javascript">
   ;(function(p,l,o,w,i,n,g){if(!p[i]){p.GlobalSnowplowNamespace=p.GlobalSnowplowNamespace||[];


### PR DESCRIPTION
Ticket: https://bcmines.atlassian.net/browse/NRPT-306

This PR adds the config service that will load various configuration details on app load.  It uses this service to check if there are any messages that should be displayed to the user in a modal. When the user dismisses the the modal a cookie is set to prevent it from opening again unless a new message is added.

Testing note: The config service is not going to work due to the age of the nginx-runtime image. There is a ticket to get that updated.  In order to test you will need to adjust line 33 of app.comonent.ts and set it to a response you would expect from the config API endpoint.