### PR TITLE
EE-1137: Adding logging mechanism

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -31,6 +31,9 @@ import { TagInputModule } from 'ngx-chips';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { EnforcementActionsComponent } from 'app/static-pages/enforcement-actions/enforcement-actions.component';
 
+// logger service
+import { LoggerService } from './services/logger.service';
+
 @NgModule({
   declarations: [
     AppComponent,
@@ -66,7 +69,7 @@ import { EnforcementActionsComponent } from 'app/static-pages/enforcement-action
     MapModule,
     SharedModule
   ],
-  providers: [ProponentService, CookieService],
+  providers: [ProponentService, CookieService, LoggerService],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ProjectService } from 'app/services/project.service';
 import { Api } from 'app/services/api';
+import { LoggerService } from 'app/services/logger.service';
 
 @Component({
   selector: 'app-home',
@@ -10,12 +11,14 @@ import { Api } from 'app/services/api';
 export class HomeComponent implements OnInit {
   numProjects: Number;
   hostname: String;
-  constructor( private projectService: ProjectService, private api: Api) { }
+  constructor( private projectService: ProjectService,
+               private api: Api,
+               private logger: LoggerService) { }
 
   ngOnInit() {
     this.projectService.getAll().subscribe(
       data => { this.numProjects = data ? data.length : 0; },
-      error => console.log(error)
+      error => this.logger.log(error)
     );
     this.hostname = this.api.hostnameNRPTI;
     window.scrollTo(0, 0);

--- a/src/app/projects/project-detail/authorizations/authorizations-tab-content.component.ts
+++ b/src/app/projects/project-detail/authorizations/authorizations-tab-content.component.ts
@@ -4,6 +4,7 @@ import { Subscription } from 'rxjs';
 
 import { Project } from 'app/models/project';
 import { CollectionsGroup } from 'app/models/collection';
+import { LoggerService } from 'app/services/logger.service';
 
 @Component({
   selector: 'app-authorizations-tab-content',
@@ -19,13 +20,13 @@ export class AuthorizationsTabContentComponent implements OnInit, OnDestroy {
   // private fields
   private sub: Subscription;
 
-  constructor(private route: ActivatedRoute) { }
+  constructor(private route: ActivatedRoute, private logger: LoggerService) { }
 
   ngOnInit(): void {
     this.loading = true;
     this.sub = this.route.parent.data.subscribe(
       (data: {project: Project}) => this.parseData(data),
-      error => console.log(error),
+      error => this.logger.log(error),
       () => this.loading = false
     );
   }

--- a/src/app/projects/project-detail/compliance/compliance-tab-content.component.ts
+++ b/src/app/projects/project-detail/compliance/compliance-tab-content.component.ts
@@ -4,6 +4,7 @@ import { Subscription } from 'rxjs';
 
 import { Project } from 'app/models/project';
 import { CollectionsArray } from 'app/models/collection';
+import { LoggerService } from 'app/services/logger.service';
 
 @Component({
   selector: 'app-compliance-tab-content',
@@ -23,13 +24,13 @@ export class ComplianceTabContentComponent implements OnInit, OnDestroy {
   // private fields
   private sub: Subscription;
 
-  constructor(private route: ActivatedRoute) { }
+  constructor(private route: ActivatedRoute, private logger: LoggerService) { }
 
   ngOnInit(): void {
     this.loading = true;
     this.sub = this.route.parent.data.subscribe(
       (data: { project: Project }) => this.parseData(data),
-      error => console.log(error),
+      error => this.logger.log(error),
       () => this.loading = false
     );
   }

--- a/src/app/projects/project-detail/documents/documents-tab-content.component.ts
+++ b/src/app/projects/project-detail/documents/documents-tab-content.component.ts
@@ -4,6 +4,7 @@ import { Subscription } from 'rxjs';
 
 import { Project } from 'app/models/project';
 import { CollectionsArray } from 'app/models/collection';
+import { LoggerService } from 'app/services/logger.service';
 
 @Component({
   selector: 'app-documents-tab-content',
@@ -23,13 +24,13 @@ export class DocumentsTabContentComponent implements OnInit, OnDestroy {
   // private fields
   private sub: Subscription;
 
-  constructor(private route: ActivatedRoute) { }
+  constructor(private route: ActivatedRoute, private logger: LoggerService) { }
 
   ngOnInit(): void {
     this.loading = true;
     this.sub = this.route.parent.data.subscribe(
       (data: { project: Project }) => this.parseData(data),
-      error => console.log(error),
+      error => this.logger.log(error),
       () => this.loading = false
     );
   }

--- a/src/app/projects/project-detail/overview/overview-tab-content.component.ts
+++ b/src/app/projects/project-detail/overview/overview-tab-content.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute } from '@angular/router';
 import { Subscription } from 'rxjs';
 
 import { Project } from 'app/models/project';
+import { LoggerService } from 'app/services/logger.service';
 
 @Component({
   selector: 'app-overview-tab-content',
@@ -17,13 +18,13 @@ export class OverviewTabContentComponent implements OnInit, OnDestroy {
   // private fields
   private sub: Subscription;
 
-  constructor(private route: ActivatedRoute) { }
+  constructor(private route: ActivatedRoute, private logger: LoggerService) { }
 
   ngOnInit(): void {
     this.loading = true;
     this.sub = this.route.parent.data.subscribe(
       (data: { project: Project }) => this.project = data.project,
-      error => console.log(error),
+      error => this.logger.log(error),
       () => this.loading = false
     );
   }

--- a/src/app/projects/project-detail/project-detail.component.ts
+++ b/src/app/projects/project-detail/project-detail.component.ts
@@ -3,6 +3,7 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { Subscription } from 'rxjs';
 
 import { Project } from 'app/models/project';
+import { LoggerService } from 'app/services/logger.service';
 
 @Component({
   selector: 'app-project-detail',
@@ -25,7 +26,9 @@ export class ProjectDetailComponent implements OnInit, OnDestroy {
   private sub: Subscription;
   private pageYOffset: number;
 
-  constructor(private route: ActivatedRoute, private router: Router) { }
+  constructor(private route: ActivatedRoute,
+              private router: Router,
+              private logger: LoggerService) { }
 
   ngOnInit(): void {
     this.loading = true;
@@ -34,13 +37,13 @@ export class ProjectDetailComponent implements OnInit, OnDestroy {
     // wait for the resolver to retrieve the project details from back-end
     this.sub = this.route.data.subscribe(
       (data: { project: Project }) => this.parseData(data),
-      error => console.log(error)
+      error => this.logger.log(error)
     );
     // watch for route change events and restore Y scroll position
     this.router.events.subscribe(() => {
       this.restoreYOffset();
     },
-    error => console.log(error));
+    error => this.logger.log(error));
 
     window.scrollTo(0, 0);
   }

--- a/src/app/projects/project-list/project-list.component.ts
+++ b/src/app/projects/project-list/project-list.component.ts
@@ -3,6 +3,7 @@ import { PaginationInstance } from 'ngx-pagination';
 
 import { Project } from 'app/models/project';
 import { ProjectService } from 'app/services/project.service';
+import { LoggerService } from 'app/services/logger.service';
 
 @Component({
   selector: 'app-project-list',
@@ -30,14 +31,16 @@ export class ProjectListComponent implements OnInit {
     currentPage: 1
   };
 
-  constructor(private projectService: ProjectService, private _changeDetectionRef: ChangeDetectorRef) { }
+  constructor(private projectService: ProjectService,
+              private _changeDetectionRef: ChangeDetectorRef,
+              private logger: LoggerService) { }
 
   ngOnInit() {
     this.loading = true;
     window.scrollTo(0, 0);
     this.projectService.getAll().subscribe(
       data => this.parseData(data),
-      error => console.log(error)
+      error => this.logger.log(error)
     );
   }
 

--- a/src/app/services/logger.service.spec.ts
+++ b/src/app/services/logger.service.spec.ts
@@ -1,0 +1,18 @@
+import { TestBed, inject } from '@angular/core/testing';
+import { LoggerService } from 'app/services/logger.service';
+
+describe('LoggerService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        LoggerService
+      ],
+      declarations: [],
+      imports: []
+    });
+  });
+
+  it('should be created', inject([LoggerService], (service: LoggerService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/services/logger.service.ts
+++ b/src/app/services/logger.service.ts
@@ -69,10 +69,7 @@ export class LoggerService {
   }
 
   private entryToString(logEntry) {
-    return `${logEntry.level <= 1 ? 'DEBUG' :
-              logEntry.level === 2 ? 'INFO' :
-              logEntry.level === 3 ? 'WARN' :
-              logEntry.level === 4 ? 'ERROR' : 'FATAL'}${this.logWithDate ? ' : ' + logEntry.date : ''} : ${logEntry.message}`;
+    return `${LogLevel[logEntry.level]}${this.logWithDate ? ' : ' + logEntry.date : ''} : ${logEntry.message}`;
   }
 
   private shouldLog(level: LogLevel): boolean {

--- a/src/app/services/logger.service.ts
+++ b/src/app/services/logger.service.ts
@@ -1,0 +1,86 @@
+import { Injectable, isDevMode } from '@angular/core';
+
+export enum LogLevel {
+  All = 0,
+  Debug = 1,
+  Info = 2,
+  Warn = 3,
+  Error = 4,
+  Fatal = 5,
+  Off = 6
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class LoggerService {
+  level: LogLevel = LogLevel.Off;
+  logWithDate = true;
+
+  // For future enhancement, constructor could be updated to take a config struct
+  // and move providedIn to a forRoot call.
+  constructor() {
+    if (isDevMode()) {
+      this.level = LogLevel.All;
+    } else {
+      this.level = LogLevel.Fatal;
+    }
+  }
+
+  debug(msg: any) {
+    this.log(msg, LogLevel.Debug);
+  }
+
+  info(msg: any) {
+    this.log(msg, LogLevel.Info);
+  }
+
+  warn(msg: any) {
+    this.log(msg, LogLevel.Warn);
+  }
+
+  error(msg: any) {
+    this.log(msg, LogLevel.Error);
+  }
+
+  fatal(msg: any) {
+    this.log(msg, LogLevel.Fatal);
+  }
+
+  log(msg: any, level: LogLevel = LogLevel.Debug) {
+    if (this.shouldLog(level)) {
+
+      const logEntry = {
+        level: level,
+        date: new Date(),
+        message: msg
+      };
+
+      console.log(this.entryToString(logEntry));
+
+      // Future enhancement
+      // add a 'toConsole: boolean = true' to the function params, then:
+      // if (toConsole) {
+      //   console.log(this.entryToString(logEntry));
+      // } else {
+      //   /* Implement an external logging mechanism (for example, API config/logging service?) */
+      // }
+    }
+  }
+
+  private entryToString(logEntry) {
+    return `${logEntry.level <= 1 ? 'DEBUG' :
+              logEntry.level === 2 ? 'INFO' :
+              logEntry.level === 3 ? 'WARN' :
+              logEntry.level === 4 ? 'ERROR' : 'FATAL'}${this.logWithDate ? ' : ' + logEntry.date : ''} : ${logEntry.message}`;
+  }
+
+  private shouldLog(level: LogLevel): boolean {
+    if ((level >= this.level && level !== LogLevel.Off) ||
+         this.level === LogLevel.All) {
+      return true;
+    }
+
+    return false;
+  }
+}


### PR DESCRIPTION
Implementation of a simple logging service in angular. Removal of console.logs and piping through the service. Currently the code checks if we're running in angulars development mode and adjusts logging level based on that, but it can easily be enhanced to be populated by the config service. I did not include a module like winston, etc, as they're generally server side components and quite bloated for what we need.

Open for a few additional enhancements that wouldn't be to tricky to implement right away (a few more hours at most):
Construct via the config service in NRPTI so we can set logging level, etc. on the fly
Implement a logging endpoint so logs can be piped directly to the service

See ticket [EE-1137](https://bcmines.atlassian.net/browse/EE-1137)