### PR TITLE
update BCMI nginx runtime template to support new env var retrieval

### DIFF
--- a/openshift/templates/nginx-runtime/Dockerfile
+++ b/openshift/templates/nginx-runtime/Dockerfile
@@ -1,34 +1,24 @@
+# Use the offical nginx (based on debian)
 FROM nginx:mainline
 
-ENV STI_SCRIPTS_PATH=/usr/libexec/s2i
+# Required for HTTP Basic feature
+RUN apt-get update && apt-get install openssl
 
-COPY ./s2i/bin/ $STI_SCRIPTS_PATH/
-LABEL io.openshift.s2i.scripts-url=image://$STI_SCRIPTS_PATH
+# Copy our OpenShift s2i scripts over to default location
+COPY ./s2i/bin/ /usr/libexec/s2i/
+
+# Expose this variable to OpenShift
+LABEL io.openshift.s2i.scripts-url=image:///usr/libexec/s2i
+
+# Copy config from source to container
 COPY nginx.conf.template /tmp/
-COPY default.conf /etc/nginx/conf.d/
-RUN mkdir -p /etc/nginx/
-RUN echo "" > /etc/nginx/publicServerEnvironmentSettings.js
-RUN mkdir -p /tmp/app/dist/
-RUN ln -sf /etc/nginx/publicServerEnvironmentSettings.js /tmp/app/dist/publicServerEnvironmentSettings.js
-# changed /etc to /etc/nginx as error thrown from ibm run cloud on this line
-# /etc/nginx was seen to require chmod 777 much later in deployment
-# RUN chmod -R 0777 /tmp /var /etc/nginx /mnt $STI_SCRIPTS_PATH/
-# =================================================================================
+COPY fetch_env.js /tmp/
+
 # Fix up permissions
-# ref: https://torstenwalter.de/openshift/nginx/2017/08/04/nginx-on-openshift.html
-# - S2I sripts must be executable
-# - Make sure nginx can read and write it's working directories.
-# - The container dynamically configures nginx on startup
-# - The application artifacts live in /tmp
-# ---------------------------------------------------------------------------------
-RUN chmod -R g+rwx $STI_SCRIPTS_PATH
-RUN chmod g+rw /var/cache/nginx \
-               /var/run \
-               /var/log/nginx \
-               /etc/nginx/publicServerEnvironmentSettings.js \
-               /etc/nginx/nginx.conf \
-               /tmp
-# =================================================================================
-RUN chmod 777 /run
+RUN chmod -R 0777 /tmp /var /run /etc /mnt /usr/libexec/s2i/
+
+# Nginx runs on port 8080 by default
 EXPOSE 8080
+
+# Switch to usermode
 USER 104

--- a/openshift/templates/nginx-runtime/fetch_env.js
+++ b/openshift/templates/nginx-runtime/fetch_env.js
@@ -1,0 +1,3 @@
+function fetch_config_endpoint(r) {
+  return process.env.CONFIG_ENDPOINT;
+}

--- a/openshift/templates/nginx-runtime/nginx-runtime.json
+++ b/openshift/templates/nginx-runtime/nginx-runtime.json
@@ -28,18 +28,15 @@
         "source": {
           "type": "Git",
           "git": {
-            "uri": "${GIT_REPO_URL}",
-            "ref": "${GIT_REPO_BRANCH}"
+            "ref": "${GIT_REF}",
+            "uri": "${GIT_REPO_URL}"
           },
-          "contextDir": "openshift/templates/nginx-runtime/"
+          "contextDir": "${SOURCE_CONTEXT_DIR}"
         },
         "strategy": {
           "type": "Docker"
         },
         "triggers": [
-          {
-            "type": "ImageChange"
-          },
           {
             "type": "ConfigChange"
           }
@@ -47,7 +44,7 @@
         "output": {
           "to": {
             "kind": "ImageStreamTag",
-            "name": "${NAME}:latest"
+            "name": "${NAME}:${OUTPUT_IMAGE_TAG}"
           }
         },
         "resources": {},
@@ -69,16 +66,30 @@
     {
       "name": "GIT_REPO_URL",
       "displayName": "Git Repo URL",
-      "description": "The URL to the customized project copy of the original common angular scaffold project https://github.com/bcgov/angular-scaffold.",
+      "description": "The URL to your customized project copy of the original common angular scaffold project https://github.com/bcgov/angular-scaffold.",
       "required": true,
       "value": "https://github.com/bcgov/mem-mmti-public"
     },
     {
-      "name": "GIT_REPO_BRANCH",
-      "displayName": "Git Repo Branch",
-      "description": "The branch with your GIT repo.",
+      "name": "GIT_REF",
+      "displayName": "Git Reference",
+      "description": "The git reference or branch.",
       "required": true,
       "value": "dev"
+    },
+    {
+      "name": "SOURCE_CONTEXT_DIR",
+      "displayName": "Source Context Directory",
+      "description": "The source context directory.",
+      "required": true,
+      "value": "openshift/templates/nginx-runtime/"
+    },
+    {
+      "name": "OUTPUT_IMAGE_TAG",
+      "displayName": "Output Image Tag",
+      "description": "The tag given to the built image.",
+      "required": true,
+      "value": "latest"
     }
   ]
 }

--- a/openshift/templates/nginx-runtime/nginx.conf.template
+++ b/openshift/templates/nginx-runtime/nginx.conf.template
@@ -1,15 +1,18 @@
 worker_processes  auto;
+load_module modules/ngx_http_js_module.so;
+
+env CONFIG_ENDPOINT;
 
 error_log  /var/log/nginx/error.log;
 pid        /var/run/nginx.pid;
-
 
 events {
     worker_connections  4096;
 }
 
-
 http {
+    js_include    /tmp/fetch_env.js;
+    js_set        $config_endpoint        fetch_config_endpoint;
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
     server_tokens off;
@@ -17,6 +20,7 @@ http {
     # ip filtering
     %IpFilterRules%
 
+    # logging rules
     geo $loggable {
         default 1;
         %RealIpFrom% 0;
@@ -52,7 +56,66 @@ http {
     #default throttle; not inherited if set in nested level
     limit_req zone=bra5 burst=100;
 
-    client_max_body_size 100m;
+    # HTTP Basic rules
+    auth_basic_user_file /tmp/.htpasswd;
 
-    include /etc/nginx/conf.d/*.conf;
+    server {
+        listen       8080;
+        server_name  localhost;
+
+        # add in most common security headers
+        add_header Content-Security-Policy "default-src * data: blob: filesystem: 'unsafe-inline' 'unsafe-eval'";
+        add_header Strict-Transport-Security "max-age=86400; includeSubDomains";
+        add_header X-Content-Type-Options "nosniff";
+        add_header X-XSS-Protection 1;
+        add_header X-Frame-Options DENY;
+
+        # serve our angular app here
+        location / {
+            root   /tmp/app/dist;
+            index  index.html index.htm;
+            try_files $uri /index.html;
+            gzip            on;
+            gzip_min_length 1000;
+            gzip_types      *;
+
+            # Deploy-time configurable
+            %HTTP_BASIC%
+        }
+
+        # redirect server error pages to the static page /50x.html
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/share/nginx/html;
+        }
+        
+        # Serve dynamic configuration information such as feature flags, api endpoints, etc
+        # from this apps location:  <http:// | https://><domain>/config
+        location /api/config {
+          proxy_pass $config_endpoint;
+
+          # Ensure HTTP get passed thru
+          proxy_pass_request_headers on;
+        }
+
+        # For status of ngnix service, OpenShift is configured to call this
+        location /nginx_status {
+            # Enable Nginx stats
+            stub_status on;
+
+            # Only allow access from localhost
+            allow 127.0.0.1;
+            
+            #Allowing only 127.0.0.1 leads to error below:
+            #[error]access forbidden by rule, client: 172.51.48.1, server: localhost, request: "GET /nginx_status HTTP/1.1", host: "172.51.49.14:8080"
+            allow 172.51.0.0/16;
+
+            # Other request should be denied
+            deny all;
+
+            # No need to log this request, its just noise
+            access_log off;
+        }
+
+    }
 }

--- a/openshift/templates/nginx-runtime/s2i/bin/run
+++ b/openshift/templates/nginx-runtime/s2i/bin/run
@@ -1,15 +1,12 @@
 #!/bin/bash
-echo run script starting...
-sed "s~%RealIpFrom%~${RealIpFrom:-172.51.0.0/16}~g; s~%IpFilterRules%~${IpFilterRules}~g; s~%AdditionalRealIpFromRules%~${AdditionalRealIpFromRules}~g" /tmp/nginx.conf.template > /etc/nginx/nginx.conf
 
-echo "window.localStorage.setItem('from_public_server--remote_api_path', '${REMOTE_API_PATH:-set-in-project-nginx-runtime}');" > /etc/nginx/publicServerEnvironmentSettings.js;
-echo "window.localStorage.setItem('from_public_server--remote_admin_path', '${REMOTE_ADMIN_PATH:-set-in-project-nginx-runtime}');" >> /etc/nginx/publicServerEnvironmentSettings.js;
-echo "window.localStorage.setItem('from_public_server--deployment_env', '${DEPLOYMENT_ENVIRONMENT:-set-in-project-nginx-runtime}');" >> /etc/nginx/publicServerEnvironmentSettings.js;
-echo "window.localStorage.setItem('from_public_server--banner_colour', '${BANNER_COLOUR:-no-banner-colour-set}');" >> /etc/nginx/publicServerEnvironmentSettings.js;
+echo "---> replacing configuration"
+sed "s~%RealIpFrom%~${RealIpFrom:-172.51.0.0/16}~g; s~%IpFilterRules%~${IpFilterRules}~g; s~%AdditionalRealIpFromRules%~${AdditionalRealIpFromRules}~g; s~%HTTP_BASIC%~${HTTP_BASIC}~g" /tmp/nginx.conf.template > /etc/nginx/nginx.conf
 
 if [ -n "$HTTP_BASIC_USERNAME" ] && [ -n "$HTTP_BASIC_PASSWORD" ]; then
     echo "---> Generating .htpasswd file"
     `echo "$HTTP_BASIC_USERNAME:$(openssl passwd -crypt $HTTP_BASIC_PASSWORD)" > /tmp/.htpasswd`
 fi
 
+echo "---> starting nginx"
 /usr/sbin/nginx -g "daemon off;"


### PR DESCRIPTION
Updates the ngin-runtime templates to match latest version and include the support for the new config service 
- [NRPT-394](https://bcmines.atlassian.net/browse/NRPT-394)