### PR TITLE
NPRT-442 Fix Authorization tab showing incorrect collections data

### DIFF
--- a/src/app/projects/project-detail/authorizations/authorizations-tab-content.component.html
+++ b/src/app/projects/project-detail/authorizations/authorizations-tab-content.component.html
@@ -11,7 +11,7 @@
     <section class="auth-section" *ngIf="collections[agency.id].length > 0">
       <h3>{{agency.act}} <span>{{agency.name}}</span></h3>
       <div class="accordion authorizations-list" id="{{agency.htmlId}}" role="tablist" aria-multiselectable="false">
-        <div class="accordion__collapse-item" *ngFor="let c of collections.empr.items">
+        <div class="accordion__collapse-item" *ngFor="let c of collections[agency.id].items">
           <div class="accordion__collapse-header" role="tab" id="heading-{{c._id}}">
             <a class="accordion__collapse-header--column toggle collapsed" data-ng-if="c.documents" data-toggle="collapse" href="#collapse-{{c._id}}"
               aria-expanded="true" aria-controls="collapseOne">


### PR DESCRIPTION
https://bcmines.atlassian.net/browse/NRPT-442

Fixed a bug that's causing the Authorizations tab to display EMPR collections for all agencies.