### PR TITLE
Added support for Amalgamated permits

### DIFF
--- a/src/app/models/collection.ts
+++ b/src/app/models/collection.ts
@@ -32,6 +32,7 @@ export class Collection {
         switch (this.type) {
           case 'Permit':
           case 'Certificate':
+          case 'Amalgamated Permit':
           case 'Permit Amendment':
           case 'Certificate Amendment':
             this.parentType = 'Authorizations';
@@ -58,7 +59,17 @@ export class Collection {
 
       // Check status next
       if (this.parentType === 'Authorizations' && !this.status) {
-        this.status = (this.type === 'Permit' || this.type === 'Certificate') ? 'Issued' : 'Amended';
+        switch (this.type) {
+          case 'Permit':
+          case 'Certificate':
+            this.status = 'Issued';
+            break;
+          case 'Amalgamated Permit':
+            this.status = 'Amalgamated';
+            break;
+          default:
+            this.status = 'Amended';
+        }
       }
 
       // Set documents

--- a/src/app/pipes/remove-string-value.pipe.spec.ts
+++ b/src/app/pipes/remove-string-value.pipe.spec.ts
@@ -2,7 +2,6 @@ import { RemoveStringValuePipe } from 'app/pipes/remove-string-value.pipe';
 
 describe('RemoveStringValuePipe', () => {
 
-  const toReplace = ' Amendment';
   let value: string;
   let expectedResponse: string;
 
@@ -13,7 +12,16 @@ describe('RemoveStringValuePipe', () => {
       value = 'Permit Amendment Amended';
       expectedResponse = 'Permit Amended';
 
-      expect(pipe.transform(value, toReplace)).toBe(expectedResponse);
+      expect(pipe.transform(value, ' Amendment')).toBe(expectedResponse);
+    });
+  });
+
+  describe('given input with duplicate string value match first instance', () => {
+    it('returns expected output', () => {
+      value = 'Amalgamated Permit Amalgamated';
+      expectedResponse = 'Permit Amalgamated';
+
+      expect(pipe.transform(value, 'Amalgamated')).toBe(expectedResponse);
     });
   });
 
@@ -22,7 +30,7 @@ describe('RemoveStringValuePipe', () => {
       value = 'Permit Amended';
       expectedResponse = 'Permit Amended';
 
-      expect(pipe.transform(value, toReplace)).toBe(expectedResponse);
+      expect(pipe.transform(value, ' Amendment')).toBe(expectedResponse);
     });
   });
 });

--- a/src/app/projects/project-detail/authorizations/authorizations-tab-content.component.html
+++ b/src/app/projects/project-detail/authorizations/authorizations-tab-content.component.html
@@ -24,7 +24,7 @@
             </a>
             <span class="accordion__collapse-header--column authorizations-list__name-col">{{formatDisplayName(c)}}</span>
             <span class="accordion__collapse-header--column authorizations-list__date-col">
-              <span>{{c.type | removeStringValue: "Amendment"}} {{c.status}}</span> -
+              <span>{{c.type | removeStringValue: "Amendment" | removeStringValue: "Amalgamated"}} {{c.status}}</span> -
               <span>{{c.date | date:'yyyy-MM-dd'}}</span>
             </span>
           </div>


### PR DESCRIPTION
Currently BCMI doesn't display Amalgamated permits pulled through from NRPTI and doesn't know how to handle them leaving them showing up under the 'Other' Category.

This PR adds support for Amalgamated permits, ensuring the text is nicely formatted and has test coverage.