### PR TITLE
[FEATURE][BCMI-405] Add dynamic routes, GraphQL, content resolver

### DIFF
--- a/bcmi/package-lock.json
+++ b/bcmi/package-lock.json
@@ -22,10 +22,13 @@
         "@angular/platform-browser-dynamic": "18.2.4",
         "@angular/platform-server": "18.2.4",
         "@angular/router": "18.2.4",
+        "@apollo/client": "^3.0.0",
         "@bluehalo/ngx-leaflet": "^18.0.2",
         "@ng-bootstrap/ng-bootstrap": "17.0.1",
+        "apollo-angular": "^7.2.0",
         "bootstrap": "5.3.3",
         "core-js": "3.38.1",
+        "graphql": "^16",
         "jquery": "3.7.1",
         "leaflet": "1.9.4",
         "leaflet.markercluster": "~1.5.3",
@@ -787,6 +790,49 @@
         "@angular/core": "18.2.4",
         "@angular/platform-browser": "18.2.4",
         "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@apollo/client": {
+      "version": "3.11.8",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.11.8.tgz",
+      "integrity": "sha512-CgG1wbtMjsV2pRGe/eYITmV5B8lXUCYljB2gB/6jWTFQcrvirUVvKg7qtFdjYkQSFbIffU1IDyxgeaN81eTjbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@wry/caches": "^1.0.0",
+        "@wry/equality": "^0.5.6",
+        "@wry/trie": "^0.5.0",
+        "graphql-tag": "^2.12.6",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.18.0",
+        "prop-types": "^15.7.2",
+        "rehackt": "^0.1.0",
+        "response-iterator": "^0.2.6",
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.10.3",
+        "tslib": "^2.3.0",
+        "zen-observable-ts": "^1.2.5"
+      },
+      "peerDependencies": {
+        "graphql": "^15.0.0 || ^16.0.0",
+        "graphql-ws": "^5.5.5",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0",
+        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql-ws": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3336,6 +3382,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -6847,6 +6902,54 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "node_modules/@wry/caches": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz",
+      "integrity": "sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/context": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.4.tgz",
+      "integrity": "sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/equality": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
+      "integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/trie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz",
+      "integrity": "sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -7163,6 +7266,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/apollo-angular": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/apollo-angular/-/apollo-angular-7.2.0.tgz",
+      "integrity": "sha512-YPpRMkV7Le4VKyYfBuwG4WntAg00gJozwvVKtgtYyFVgsqaIUKpFc0mM0RYWoMoULxzkHRNOFYh57PXSrHQWjg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@angular/core": "^17.0.0 || ^18.0.0",
+        "@apollo/client": "^3.0.0",
+        "graphql": "^15.0.0 || ^16.0.0",
+        "rxjs": "^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/app-root-path": {
@@ -11278,6 +11399,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/graphql": {
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.9.0.tgz",
+      "integrity": "sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-tag": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
     "node_modules/handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -11345,6 +11490,21 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/hosted-git-info": {
       "version": "7.0.2",
@@ -15518,6 +15678,18 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -16556,10 +16728,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16650,6 +16819,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optimism": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.0.tgz",
+      "integrity": "sha512-tGn8+REwLRNFnb9WmcY5IfpOqeX2kpaYJ1s6Ae3mn12AeydLkR3j+jSCmVQFoXqU8D41PAJ1RG1rCRNWmNZVmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@wry/caches": "^1.0.0",
+        "@wry/context": "^0.7.0",
+        "@wry/trie": "^0.4.3",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/optimism/node_modules/@wry/trie": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.4.3.tgz",
+      "integrity": "sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/optionator": {
@@ -17601,6 +17794,23 @@
         "node": ">= 6"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -17988,6 +18198,24 @@
         "jsesc": "bin/jsesc"
       }
     },
+    "node_modules/rehackt": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.1.0.tgz",
+      "integrity": "sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -18115,6 +18343,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/response-iterator": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/response-iterator/-/response-iterator-0.2.6.tgz",
+      "integrity": "sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/restore-cursor": {
@@ -19451,7 +19688,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
       "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
@@ -19941,6 +20177,18 @@
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/ts-invariant": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
+      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ts-jest": {
@@ -22129,6 +22377,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zen-observable": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
+      "license": "MIT"
+    },
+    "node_modules/zen-observable-ts": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
+      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "zen-observable": "0.8.15"
       }
     },
     "node_modules/zod": {

--- a/bcmi/package.json
+++ b/bcmi/package.json
@@ -28,6 +28,7 @@
     "@angular/router": "18.2.4",
     "@bluehalo/ngx-leaflet": "^18.0.2",
     "@ng-bootstrap/ng-bootstrap": "17.0.1",
+    "apollo-angular": "^7.2.0",
     "bootstrap": "5.3.3",
     "core-js": "3.38.1",
     "jquery": "3.7.1",
@@ -46,7 +47,9 @@
     "tether": "2.0.0",
     "tslib": "^2.3.0",
     "typescript": "5.5.4",
-    "zone.js": "~0.14.10"
+    "zone.js": "~0.14.10",
+    "@apollo/client": "^3.0.0",
+    "graphql": "^16"
   },
   "devDependencies": {
     "@angular-builders/jest": "^18.0.0",

--- a/bcmi/src/app/app.component.html
+++ b/bcmi/src/app/app.component.html
@@ -19,7 +19,7 @@
 						aria-expanded="false"><span>Find Mines in BC</span><span class="caret"></span>
 					</a>
 					<div class="dropdown-menu dm-sm dropdown-menu-right" aria-labelledby="findEAProjects">
-						<a class="dropdown-item" href="/projects" [routerLink]="['/projects']" tabindex="5">
+						<a class="dropdown-item" href="/mines" [routerLink]="['/mines']" tabindex="5">
 							<strong>Find Mines by List</strong>
 							<span class="dd-item-desc">View a list of major mines in British Columbia</span>
 						</a>
@@ -123,7 +123,7 @@
 					<h5>Find Mines In British Columbia</h5>
 					<ul>
 						<li>
-							<a href="/projcts" [routerLink]="['/projects']">Find Mines by List</a>
+							<a href="/projcts" [routerLink]="['/mines']">Find Mines by List</a>
 						</li>
 						<li>
 							<a href="/map" [routerLink]="['/map']">Find Mines by Map</a>
@@ -138,7 +138,7 @@
 							<a href="/topics-of-interest" [routerLink]="['/topics-of-interest']">Topics of Interest</a>
 						</li>
 						<li>
-							<a href="/projects" [routerLink]="['/projects']">Find Mines in BC</a>
+							<a href="/mines" [routerLink]="['/mines']">Find Mines in BC</a>
 						</li>
 					</ul>
 					<h5>Our Processes &amp; Procedures</h5>

--- a/bcmi/src/app/app.component.spec.ts
+++ b/bcmi/src/app/app.component.spec.ts
@@ -7,6 +7,8 @@ import { ConfigService } from '@services/config.service';
 import { HttpClientModule } from '@angular/common/http';
 import { AppComponent } from './app.component';
 import { SafeHtmlPipe } from '@pipes/safe-html.pipe';
+import { Apollo } from 'apollo-angular';
+import { ContentService } from './services/content-service';
 
 describe('AppComponent', () => {
   beforeEach(waitForAsync(() => {
@@ -14,7 +16,9 @@ describe('AppComponent', () => {
       providers: [
         CookieService,
         Api,
-        ConfigService
+        ConfigService,
+        Apollo,
+        ContentService
       ],
       declarations: [
         AppComponent,

--- a/bcmi/src/app/app.config.ts
+++ b/bcmi/src/app/app.config.ts
@@ -1,9 +1,27 @@
-import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { ApplicationConfig, inject, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
 import { provideClientHydration } from '@angular/platform-browser';
+import { provideHttpClient } from '@angular/common/http';
+import { provideApollo } from 'apollo-angular';
+import { InMemoryCache } from '@apollo/client/core';
+import { HttpLink } from 'apollo-angular/http';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(routes), provideClientHydration()]
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(routes),
+    provideClientHydration(),
+    provideHttpClient(),
+    provideApollo(() => {
+      const httpLink = inject(HttpLink);
+ 
+      return {
+        link: httpLink.create({ uri: '/graphql' }),
+        cache: new InMemoryCache(),
+        // other options...
+      };
+    }),
+  ]
 };

--- a/bcmi/src/app/app.module.ts
+++ b/bcmi/src/app/app.module.ts
@@ -37,6 +37,7 @@ import { RouterModule } from '@angular/router';
 import { LeafletModule } from '@bluehalo/ngx-leaflet';
 import { GraphQLModule } from './graphql.module';
 import { PageComponent } from './static-pages/page/page.component';
+import { ContentService } from './services/content-service';
 
 export function initConfig(configService: ConfigService) {
   return () => configService.init();
@@ -86,9 +87,10 @@ export function initConfig(configService: ConfigService) {
       provide: APP_INITIALIZER,
       useFactory: initConfig,
       multi: true,
-      deps: [ConfigService]
+      deps: [ConfigService,ContentService]
     },
     ProponentService,
+    ContentService,
     CookieService,
     ConfigService,
     GeocoderService,

--- a/bcmi/src/app/app.module.ts
+++ b/bcmi/src/app/app.module.ts
@@ -35,6 +35,8 @@ import { TagInputModule } from 'ngx-chips';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule } from '@angular/router';
 import { LeafletModule } from '@bluehalo/ngx-leaflet';
+import { GraphQLModule } from './graphql.module';
+import { PageComponent } from './static-pages/page/page.component';
 
 export function initConfig(configService: ConfigService) {
   return () => configService.init();
@@ -48,6 +50,7 @@ export function initConfig(configService: ConfigService) {
     ComplianceOversightComponent,
     ContactComponent,
     AuthorizationsComponent,
+    PageComponent,
     LifecycleComponent,
     TopicsOfInterestComponent,
     WaterQualityComponent,
@@ -75,7 +78,8 @@ export function initConfig(configService: ConfigService) {
     MapModule,
     SharedModule,
     RouterModule,
-    LeafletModule
+    LeafletModule,
+    GraphQLModule
   ],
   providers: [
     {

--- a/bcmi/src/app/app.routes.ts
+++ b/bcmi/src/app/app.routes.ts
@@ -10,8 +10,10 @@ import { ReclamationComponent } from './static-pages/reclamation/reclamation.com
 import { TailingsManagementComponent } from './static-pages/tailings-management/tailings-management.component';
 import { TopicsOfInterestComponent } from './static-pages/topics-of-interest/topics-of-interest.component';
 import { WaterQualityComponent } from './static-pages/water-quality/water-quality.component';
+import { PageComponent } from './static-pages/page/page.component';
 import { MainMapComponent } from './map/main-map/main-map.component';
 import { NotFoundComponent } from './not-found/not-found.component';
+import {ContentResolver} from './services/content-resolver'
 
 export const routes: Routes = [
   {
@@ -57,6 +59,13 @@ export const routes: Routes = [
   {
     path: 'map',
     component: MainMapComponent
+  },
+  {
+    path: 'page',
+    component: PageComponent,
+    resolve: {
+      pageData: ContentResolver
+    }
   },
   {
     path: '**',

--- a/bcmi/src/app/app.routes.ts
+++ b/bcmi/src/app/app.routes.ts
@@ -26,7 +26,11 @@ export const routes: Routes = [
   },
   {
     path: 'contact',
-    component: ContactComponent
+    component: PageComponent,
+    resolve: {
+      pageData: ContentResolver
+    },
+    data: {id:2}
   },
   {
     path: '',
@@ -65,7 +69,8 @@ export const routes: Routes = [
     component: PageComponent,
     resolve: {
       pageData: ContentResolver
-    }
+    },
+    data: {id:1}
   },
   {
     path: '**',

--- a/bcmi/src/app/app.routes.ts
+++ b/bcmi/src/app/app.routes.ts
@@ -1,41 +1,45 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { AuthorizationsComponent } from './static-pages/authorizations/authorizations.component';
-import { ComplianceOversightComponent } from './static-pages/compliance-oversight/compliance-oversight.component';
+//import { ComplianceOversightComponent } from './static-pages/compliance-oversight/compliance-oversight.component';
 import { ContactComponent } from './static-pages/contact/contact.component';
 import { HomeComponent } from './home/home.component';
-import { LegislationComponent } from './static-pages/legislation/legislation.component';
-import { LifecycleComponent } from './static-pages/lifecycle/lifecycle.component';
+//import { LegislationComponent } from './static-pages/legislation/legislation.component';
+//import { LifecycleComponent } from './static-pages/lifecycle/lifecycle.component';
 import { ReclamationComponent } from './static-pages/reclamation/reclamation.component';
 import { TailingsManagementComponent } from './static-pages/tailings-management/tailings-management.component';
 import { TopicsOfInterestComponent } from './static-pages/topics-of-interest/topics-of-interest.component';
 import { WaterQualityComponent } from './static-pages/water-quality/water-quality.component';
-import { PageComponent } from './static-pages/page/page.component';
 import { MainMapComponent } from './map/main-map/main-map.component';
 import { NotFoundComponent } from './not-found/not-found.component';
-import {ContentResolver} from './services/content-resolver'
 
 export const routes: Routes = [
   {
     path: 'authorizations',
     component: AuthorizationsComponent
   },
+  /* Commenting out for demo
   {
     path: 'compliance-oversight',
     component: ComplianceOversightComponent
   },
+  */
   {
     path: '',
     component: HomeComponent
   },
+  /* Commenting out for demo
   {
     path: 'legislation',
     component: LegislationComponent
   },
+  */
+  /* Commenting out for demo
   {
     path: 'lifecycle',
     component: LifecycleComponent
   },
+  */
   {
     path: 'reclamation',
     component: ReclamationComponent
@@ -51,6 +55,10 @@ export const routes: Routes = [
   {
     path: 'water-quality',
     component: WaterQualityComponent
+  },
+  {
+    path: 'contact',
+    component: ContactComponent,
   },
   {
     path: 'map',

--- a/bcmi/src/app/app.routes.ts
+++ b/bcmi/src/app/app.routes.ts
@@ -25,14 +25,6 @@ export const routes: Routes = [
     component: ComplianceOversightComponent
   },
   {
-    path: 'contact',
-    component: PageComponent,
-    resolve: {
-      pageData: ContentResolver
-    },
-    data: {id:2}
-  },
-  {
     path: '',
     component: HomeComponent
   },
@@ -63,14 +55,6 @@ export const routes: Routes = [
   {
     path: 'map',
     component: MainMapComponent
-  },
-  {
-    path: 'page',
-    component: PageComponent,
-    resolve: {
-      pageData: ContentResolver
-    },
-    data: {id:1}
   },
   {
     path: '**',

--- a/bcmi/src/app/app.routes.ts
+++ b/bcmi/src/app/app.routes.ts
@@ -2,7 +2,6 @@ import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { AuthorizationsComponent } from './static-pages/authorizations/authorizations.component';
 import { ComplianceOversightComponent } from './static-pages/compliance-oversight/compliance-oversight.component';
-import { ContactComponent } from './static-pages/contact/contact.component';
 import { HomeComponent } from './home/home.component';
 import { LegislationComponent } from './static-pages/legislation/legislation.component';
 import { LifecycleComponent } from './static-pages/lifecycle/lifecycle.component';
@@ -10,10 +9,8 @@ import { ReclamationComponent } from './static-pages/reclamation/reclamation.com
 import { TailingsManagementComponent } from './static-pages/tailings-management/tailings-management.component';
 import { TopicsOfInterestComponent } from './static-pages/topics-of-interest/topics-of-interest.component';
 import { WaterQualityComponent } from './static-pages/water-quality/water-quality.component';
-import { PageComponent } from './static-pages/page/page.component';
 import { MainMapComponent } from './map/main-map/main-map.component';
 import { NotFoundComponent } from './not-found/not-found.component';
-import {ContentResolver} from './services/content-resolver'
 
 export const routes: Routes = [
   {

--- a/bcmi/src/app/enforcement-actions/enforcement-actions-list/enforcement-actions-list.component.spec.ts
+++ b/bcmi/src/app/enforcement-actions/enforcement-actions-list/enforcement-actions-list.component.spec.ts
@@ -5,6 +5,8 @@ import { HttpClientModule } from '@angular/common/http';
 
 import { EnforcementActionsListComponent } from './enforcement-actions-list.component';
 import { ConfigService } from '@services/config.service';
+import { ContentService } from '@app/services/content-service';
+import { Apollo } from 'apollo-angular';
 
 describe('EnforcementActionsListComponent', () => {
   let component: EnforcementActionsListComponent;
@@ -12,7 +14,7 @@ describe('EnforcementActionsListComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      providers: [ConfigService],
+      providers: [ConfigService,ContentService, Apollo],
       declarations: [EnforcementActionsListComponent],
       imports: [HttpClientModule, RouterTestingModule]
     }).compileComponents();

--- a/bcmi/src/app/graphql.module.ts
+++ b/bcmi/src/app/graphql.module.ts
@@ -1,0 +1,24 @@
+import { APOLLO_OPTIONS, ApolloModule } from 'apollo-angular';
+import { HttpLink } from 'apollo-angular/http';
+import { NgModule } from '@angular/core';
+import { ApolloClientOptions, InMemoryCache } from '@apollo/client/core';
+
+const uri = 'http://localhost:1337/graphql'; // <-- add the URL of the GraphQL server here
+export function createApollo(httpLink: HttpLink): ApolloClientOptions<any> {
+  return {
+    link: httpLink.create({ uri }),
+    cache: new InMemoryCache(),
+  };
+}
+
+@NgModule({
+  exports: [ApolloModule],
+  providers: [
+    {
+      provide: APOLLO_OPTIONS,
+      useFactory: createApollo,
+      deps: [HttpLink],
+    },
+  ],
+})
+export class GraphQLModule {}

--- a/bcmi/src/app/home/home.component.html
+++ b/bcmi/src/app/home/home.component.html
@@ -7,7 +7,7 @@
           to continuing to provide effective oversight of this important sector.</p>
         <div class="hero-banner__content--cta-btns">
           <strong>Find Mines in British Columbia...</strong>
-          <a class="btn slide-l-btn hero-btn inverted" href="/projects" [routerLink]="['/projects']"><i class="material-icons">list</i><span>View List</span></a>
+          <a class="btn slide-l-btn hero-btn inverted" href="/mines" [routerLink]="['/mines']"><i class="material-icons">list</i><span>View List</span></a>
           <span>or</span>
           <a class="btn slide-l-btn hero-btn inverted" href="/map" [routerLink]="['/map']"><i class="material-icons">map</i><span>View Map</span></a>
         </div>
@@ -78,7 +78,7 @@
           <div class="feature-block">
             <h3>Find Mines in B.C.</h3>
             <p>The BC Mine Information website currently profiles {{numProjects}} major mines</p>
-            <a class="btn inverted" href="/projects" [routerLink]="['/projects']">View List</a>
+            <a class="btn inverted" href="/mines" [routerLink]="['/mines']">View List</a>
             <span>&nbsp;</span>
             <a class="btn inverted" href="/map" [routerLink]="['/map']">View Map</a>
           </div>

--- a/bcmi/src/app/home/home.component.spec.ts
+++ b/bcmi/src/app/home/home.component.spec.ts
@@ -6,6 +6,8 @@ import { Api } from '@services/api';
 import { HttpClientModule } from '@angular/common/http';
 import { HomeComponent } from '../home/home.component';
 import { Project } from '@models/project';
+import { ContentService } from '@app/services/content-service';
+import { Apollo } from 'apollo-angular';
 
 window.scrollTo = jest.fn();
 
@@ -24,7 +26,7 @@ describe('HomeComponent', () => {
     };
     TestBed.configureTestingModule({
       declarations: [HomeComponent],
-      providers: [{ provide: ProjectService, useValue: ProjectServiceStub }, Api, ConfigService],
+      providers: [{ provide: ProjectService, useValue: ProjectServiceStub }, Api, ConfigService, ContentService, Apollo],
       imports: [RouterTestingModule, HttpClientModule]
     }).compileComponents();
   }));

--- a/bcmi/src/app/map/leaflet-map/project-popup/project-popup.component.html
+++ b/bcmi/src/app/map/leaflet-map/project-popup/project-popup.component.html
@@ -14,7 +14,7 @@
       </ul>
       <div class="map-popup-desc" [innerHTML]="project.description"></div>
       <div class="map-popup-btns">
-        <a class="btn btn-sm slide-r-btn" title="View additional information about {{project.name}}" href="/p/{{project._id}}">
+        <a class="btn btn-sm slide-r-btn" title="View additional information about {{project.name}}" href="/mine/{{project._id}}">
           <span>Go to Mine Details</span><i class="material-icons">arrow_forward</i>
         </a>
         <div class="map-popup-disc">The Province has reviewed the geospatial information but makes

--- a/bcmi/src/app/map/main-map/main-map.component.spec.ts
+++ b/bcmi/src/app/map/main-map/main-map.component.spec.ts
@@ -15,6 +15,8 @@ import { TestConstants } from '@shared/test-constants';
 import { GeocoderService } from '@services/geocoder.service';
 import { Api } from '@services/api';
 import { ConfigService } from '@services/config.service';
+import { ContentService } from '@app/services/content-service';
+import { Apollo } from 'apollo-angular';
 
 @Component({
   selector: 'app-leaflet-map',
@@ -62,7 +64,9 @@ describe('MainMapComponent', () => {
         { provide: ProjectService, useValue: ProjectServiceStub },
         GeocoderService,
         Api,
-        ConfigService
+        ConfigService,
+        ContentService,
+        Apollo
       ],
       declarations: [
         MainMapComponent,

--- a/bcmi/src/app/map/search/search.component.spec.ts
+++ b/bcmi/src/app/map/search/search.component.spec.ts
@@ -10,6 +10,7 @@ import { GeocoderService } from '@services/geocoder.service';
 import { Api } from '@services/api';
 import { ConfigService } from '@services/config.service';
 import { HttpClient, HttpHandler } from '@angular/common/http';
+import { ContentService } from '@app/services/content-service';
 
 
 
@@ -34,6 +35,7 @@ describe('SearchComponent', () => {
         {provide: GeocoderService, useValue: GeocoderServiceStub },
         Api,
         ConfigService,
+        ContentService,
         HttpClient,
         HttpHandler
       ],

--- a/bcmi/src/app/models/content/page.ts
+++ b/bcmi/src/app/models/content/page.ts
@@ -1,0 +1,15 @@
+export class Page {
+    Title: String
+    Description: String
+    Content: String
+    Ongoing_card: String
+    External_card: String
+    Related_card: String
+    route: String
+    tooltip: String
+  
+    constructor() {
+    
+    }
+  }
+  

--- a/bcmi/src/app/models/content/page.ts
+++ b/bcmi/src/app/models/content/page.ts
@@ -1,15 +1,11 @@
 export class Page {
-    Title: String
-    Description: String
-    Content: String
-    Ongoing_card: String
-    External_card: String
-    Related_card: String
-    route: String
-    tooltip: String
-  
-    constructor() {
-    
-    }
+    Title: string
+    Description: string
+    Content: string
+    Ongoing_card: string
+    External_card: string
+    Related_card: string
+    route: string
+    tooltip: string
   }
   

--- a/bcmi/src/app/projects/project-detail-resolver.service.spec.ts
+++ b/bcmi/src/app/projects/project-detail-resolver.service.spec.ts
@@ -6,6 +6,8 @@ import { ProjectService } from '@services/project.service';
 import { Api } from '@services/api';
 import { ConfigService } from '@services/config.service';
 import { HttpClientModule } from '@angular/common/http';
+import { ContentService } from '@app/services/content-service';
+import { Apollo } from 'apollo-angular';
 
 describe('ProjectDetailResolverService', () => {
   beforeEach(() => {
@@ -14,7 +16,9 @@ describe('ProjectDetailResolverService', () => {
         ProjectService,
         ProjectDetailResolver,
         Api,
-        ConfigService
+        ConfigService,
+        ContentService,
+        Apollo
       ],
       declarations: [],
       imports: [

--- a/bcmi/src/app/projects/project-detail/compliance/compliance-tab-content.component.spec.ts
+++ b/bcmi/src/app/projects/project-detail/compliance/compliance-tab-content.component.spec.ts
@@ -13,6 +13,8 @@ import { ComplianceTabContentComponent } from '@projects/project-detail/complian
 import { OrderByPipe } from '@pipes/filters/order-by.pipe';
 import { HttpClientModule } from '@angular/common/http';
 import { Subscription } from 'rxjs';
+import { ContentService } from '@app/services/content-service';
+import { Apollo } from 'apollo-angular';
 
 describe('ComplianceTabContentComponent', () => {
   let component: ComplianceTabContentComponent;
@@ -36,7 +38,9 @@ describe('ComplianceTabContentComponent', () => {
     TestBed.configureTestingModule({
       providers: [
         { provide: ActivatedRoute, useValue: ActivatedRouteStub },
-        ConfigService
+        ConfigService,
+        ContentService,
+        Apollo
       ],
       declarations: [
         ComplianceTabContentComponent,

--- a/bcmi/src/app/projects/project-detail/project-detail.component.spec.ts
+++ b/bcmi/src/app/projects/project-detail/project-detail.component.spec.ts
@@ -114,7 +114,7 @@ describe('ProjectDetailComponent', () => {
   describe('gotoProjectList()', () => {
     it('should navigate to /map when no project code given', () => {
       component.gotoProjectList();
-      expect(router.navigate).toHaveBeenCalledWith(['/projects']);
+      expect(router.navigate).toHaveBeenCalledWith(['/mines']);
     });
   });
   describe('gotoMap()', () => {

--- a/bcmi/src/app/projects/project-detail/project-detail.component.spec.ts
+++ b/bcmi/src/app/projects/project-detail/project-detail.component.spec.ts
@@ -12,6 +12,7 @@ import { SiteActivitiesComponent } from '@projects/site-activities/site-activiti
 import { Api } from '@services/api';
 import { ConfigService } from '@services/config.service';
 import { Subscription } from 'rxjs';
+import { ContentService } from '@app/services/content-service';
 
 window.scrollTo = jest.fn();
 
@@ -69,7 +70,8 @@ describe('ProjectDetailComponent', () => {
           { provide: Router, useValue: router },
           LeafletMapComponent,
           { provide: ProjectService, useValue: ProjectServiceStub },
-          ConfigService
+          ConfigService,
+          ContentService
         ],
         declarations: [
           ProjectDetailComponent,

--- a/bcmi/src/app/projects/project-detail/project-detail.component.ts
+++ b/bcmi/src/app/projects/project-detail/project-detail.component.ts
@@ -63,7 +63,7 @@ export class ProjectDetailComponent implements OnInit, OnDestroy {
   }
 
   gotoProjectList(): void {
-    this.router.navigate(['/projects']);
+    this.router.navigate(['/mines']);
   }
 
   gotoMap(): void {

--- a/bcmi/src/app/projects/project-list/project-list.component.html
+++ b/bcmi/src/app/projects/project-list/project-list.component.html
@@ -94,7 +94,7 @@
                   <i class="material-icons close-icon">remove</i>
                 </a>
                 <span class="accordion__collapse-header--column project-table__project-col">
-                  <a [routerLink]="['/p', item._id]">{{item.name}}</a></span>
+                  <a [routerLink]="['/mine', item._id]">{{item.name}}</a></span>
                 <span class="accordion__collapse-header--column project-table__operator-col"><span class="inside-td">{{item.permittee}}</span></span>
                 <span class="accordion__collapse-header--column project-table__type-col" ><span class="inside-td">{{item.type}}</span></span>
                 <span class="accordion__collapse-header--column project-table__status-col" ><span class="inside-td">{{item.status}}</span></span>
@@ -114,7 +114,7 @@
                       </li>
                     </ul>
                     <div class="project-table__project-details--links">
-                      <a class="btn content-btn slide-l-btn btn-sm" [routerLink]="['/p', item._id]"><i class="material-icons">info_outline</i><span>Go to Mine Details</span></a>
+                      <a class="btn content-btn slide-l-btn btn-sm" [routerLink]="['/mine', item._id]"><i class="material-icons">info_outline</i><span>Go to Mine Details</span></a>
                       <a class="btn content-btn slide-l-btn btn-sm" href="/map" [routerLink]="['/map', { project: item._id }]"><i class="material-icons">location_on</i><span>Show on Map</span></a>
                     </div>
                   </div>

--- a/bcmi/src/app/projects/project-list/project-list.component.spec.ts
+++ b/bcmi/src/app/projects/project-list/project-list.component.spec.ts
@@ -14,6 +14,7 @@ import { ObjectFilterPipe } from '@pipes/object-filter.pipe';
 import { ProjectService } from '@services/project.service';
 import { Api } from '@services/api';
 import { ConfigService } from '@services/config.service';
+import { ContentService } from '@app/services/content-service';
 
 window.scrollTo = jest.fn();
 
@@ -37,6 +38,7 @@ describe('ProjectComponent', () => {
         {provide: ProjectService, useValue: ProjectServiceStub},
         Api,
         ConfigService,
+        ContentService
       ],
       declarations: [
         ProjectListComponent,

--- a/bcmi/src/app/projects/projects-routing.module.ts
+++ b/bcmi/src/app/projects/projects-routing.module.ts
@@ -8,11 +8,11 @@ import { TAB_NAV_ROUTES } from '@projects/project-detail/routes';
 
 const routes: Routes = [
   {
-    path: 'projects',
+    path: 'mines',
     component: ProjectListComponent
   },
   {
-    path: 'p/:code',
+    path: 'mine/:code',
     component: ProjectDetailComponent,
     resolve: {
       project: ProjectDetailResolver

--- a/bcmi/src/app/services/api.spec.ts
+++ b/bcmi/src/app/services/api.spec.ts
@@ -2,12 +2,14 @@ import { TestBed, inject } from '@angular/core/testing';
 import { HttpClientModule } from '@angular/common/http';
 import { Api } from '@services/api';
 import { ConfigService } from '@services/config.service';
+import { Apollo } from 'apollo-angular';
+import { ContentService } from './content-service';
 
 describe('Api', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientModule],
-      providers: [Api, ConfigService]
+      providers: [Api, ConfigService, ContentService, Apollo]
     });
   });
 

--- a/bcmi/src/app/services/config.service.ts
+++ b/bcmi/src/app/services/config.service.ts
@@ -1,6 +1,6 @@
-import { Injectable, Injector } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Route, Router, RouterModule } from '@angular/router';
+import { Route, Router } from '@angular/router';
 import { PageComponent } from '@app/static-pages/page/page.component';
 import { ContentResolver } from './content-resolver';
 import { ContentService } from './content-service';
@@ -27,7 +27,7 @@ export class ConfigService {
    */
   async init() {
     //Dynamically build routes based on pages in the CMS
-    let results = await this.contentService.getRoutes();
+    const results = await this.contentService.getRoutes();
     const routes: Route[] = [];
     results.forEach( (page) => {
       routes.push({path: page.attributes.route, component: PageComponent, resolve: {pageData: ContentResolver}})

--- a/bcmi/src/app/services/content-resolver.ts
+++ b/bcmi/src/app/services/content-resolver.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@angular/core';
+import { Resolve } from '@angular/router';
+import { Observable, catchError, map } from 'rxjs';
+import { Apollo, gql } from 'apollo-angular';
+import { Page } from '@app/models/content/page';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ContentResolver implements Resolve<Page> {
+
+    constructor(private readonly apollo: Apollo){}
+
+    private getPage = gql`
+    {
+        page(id: 1) {
+        data{
+            attributes{
+            Title,
+            Description
+            Content
+            Ongoing_card
+            External_card
+            Related_card
+            route
+            tooltip
+            }
+        }
+        }
+    }
+    `;
+
+    resolve(): Observable<Page> {
+    // Return an Observable that represents the API request(s) you want to
+    // execute before the route is activated.
+
+        return this.apollo.watchQuery<any>({
+            query: this.getPage
+        })
+        .valueChanges.pipe(map(result => result.data?.page.data.attributes as Page),
+        catchError(error => {
+            console.error(error);
+            return [];
+        }))
+    }
+}

--- a/bcmi/src/app/services/content-resolver.ts
+++ b/bcmi/src/app/services/content-resolver.ts
@@ -11,37 +11,34 @@ export class ContentResolver implements Resolve<Page> {
 
     constructor(private readonly apollo: Apollo){}
 
-    private getPage = function(id){
+    private getPage = function(route){
 
     return gql`
     {
-        page(id: ${id}) {
-        data{
-            attributes{
-            Title,
-            Description
-            Content
-            Ongoing_card
-            External_card
-            Related_card
-            route
-            tooltip
+        pageByRoute(route: "${route}") {
+            data{
+                attributes{
+                    Title,
+                    Description
+                    Content
+                    Ongoing_card
+                    External_card
+                    Related_card
+                    route
+                    tooltip
+                }
             }
-        }
         }
     }
     `;
     }
 
     resolve(route: ActivatedRouteSnapshot): Observable<Page> {
-    // Return an Observable that represents the API request(s) you want to
-    // execute before the route is activated.
-        const id = route.data["id"];
-
+    // Return an Observable that represents the GraphQL request to execute before the route is activated.
         return this.apollo.watchQuery<any>({
-            query: this.getPage(id)
+            query: this.getPage(route.routeConfig.path)
         })
-        .valueChanges.pipe(map(result => result.data?.page.data.attributes as Page),
+        .valueChanges.pipe(map(result => result.data?.pageByRoute.data.attributes as Page),
         catchError(error => {
             console.error(error);
             return [];

--- a/bcmi/src/app/services/content-resolver.ts
+++ b/bcmi/src/app/services/content-resolver.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Resolve } from '@angular/router';
+import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
 import { Observable, catchError, map } from 'rxjs';
 import { Apollo, gql } from 'apollo-angular';
 import { Page } from '@app/models/content/page';
@@ -11,9 +11,11 @@ export class ContentResolver implements Resolve<Page> {
 
     constructor(private readonly apollo: Apollo){}
 
-    private getPage = gql`
+    private getPage = function(id){
+
+    return gql`
     {
-        page(id: 1) {
+        page(id: ${id}) {
         data{
             attributes{
             Title,
@@ -29,13 +31,15 @@ export class ContentResolver implements Resolve<Page> {
         }
     }
     `;
+    }
 
-    resolve(): Observable<Page> {
+    resolve(route: ActivatedRouteSnapshot): Observable<Page> {
     // Return an Observable that represents the API request(s) you want to
     // execute before the route is activated.
+        const id = route.data["id"];
 
         return this.apollo.watchQuery<any>({
-            query: this.getPage
+            query: this.getPage(id)
         })
         .valueChanges.pipe(map(result => result.data?.page.data.attributes as Page),
         catchError(error => {

--- a/bcmi/src/app/services/content-service.ts
+++ b/bcmi/src/app/services/content-service.ts
@@ -1,0 +1,30 @@
+import {throwError as observableThrowError, Observable, map, catchError, firstValueFrom } from 'rxjs';
+import { Injectable } from '@angular/core';
+import { Apollo, gql } from 'apollo-angular';
+import { Page } from '@app/models/content/page';
+
+@Injectable()
+export class ContentService {
+
+  constructor(private readonly apollo: Apollo) {}
+
+  async getRoutes(): Promise<any> {
+    return this.apollo.query<any>({
+          query: gql`
+          {
+            pages{
+              data{
+                  attributes{
+                    Title,
+                    route
+                    tooltip
+                  }
+              }
+            }
+          }
+          `
+      }).pipe(map(response => response.data.pages?.data)).toPromise();
+    }
+
+}
+

--- a/bcmi/src/app/services/content-service.ts
+++ b/bcmi/src/app/services/content-service.ts
@@ -1,7 +1,6 @@
-import {throwError as observableThrowError, Observable, map, catchError, firstValueFrom } from 'rxjs';
+import { map } from 'rxjs';
 import { Injectable } from '@angular/core';
 import { Apollo, gql } from 'apollo-angular';
-import { Page } from '@app/models/content/page';
 
 @Injectable()
 export class ContentService {

--- a/bcmi/src/app/services/document.service.spec.ts
+++ b/bcmi/src/app/services/document.service.spec.ts
@@ -4,6 +4,8 @@ import { HttpClientModule } from '@angular/common/http';
 
 import { DocumentService } from '@services/document.service';
 import { ConfigService } from '@services/config.service';
+import { ContentService } from './content-service';
+import { Apollo } from 'apollo-angular';
 
 describe('DocumentService', () => {
   beforeEach(() => {
@@ -11,6 +13,8 @@ describe('DocumentService', () => {
       providers: [
         DocumentService,
         ConfigService,
+        ContentService,
+        Apollo,
         Api
       ],
       declarations: [],

--- a/bcmi/src/app/services/enforcement-actions.service.spec.ts
+++ b/bcmi/src/app/services/enforcement-actions.service.spec.ts
@@ -4,11 +4,13 @@ import { HttpClientModule } from '@angular/common/http';
 import { Api } from '@services/api';
 import { EnforcementActionsService } from './enforcement-actions.service';
 import { ConfigService } from '@services/config.service';
+import { ContentService } from './content-service';
+import { Apollo } from 'apollo-angular';
 
 describe('EnforcementActionsService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [EnforcementActionsService, Api, ConfigService],
+      providers: [EnforcementActionsService, Api, ConfigService, ContentService, Apollo],
       imports: [HttpClientModule]
     });
   });

--- a/bcmi/src/app/static-pages/contact/contact.component.html
+++ b/bcmi/src/app/static-pages/contact/contact.component.html
@@ -44,6 +44,7 @@
 </div>
 
 <!-- Confirmation Modal -->
+<!-- No longer appears. The functionality was removed -->
 <div class="modal fade" id="thanksModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
     <div class="modal-dialog" role="document">
         <div class="modal-content">

--- a/bcmi/src/app/static-pages/page/page.component.html
+++ b/bcmi/src/app/static-pages/page/page.component.html
@@ -14,11 +14,12 @@
         <main class="col-lg-8" [innerHTML]="pageData.Content">
         </main>
         <aside class="col-lg-4">
-            <section class="card">
-                <h4 class="card-header">Related Documents</h4>
+            <section class="card" *ngIf="!(pageData.Related_card === null ||  pageData.Related_card === '')">
+              <h4 class="card-header">Related Documents</h4>
                 <div [innerHTML]="pageData.Related_card" class="card-list"></div>
             </section>
-            <section class="card">
+
+            <section class="card" *ngIf="!(pageData.External_card === null ||  pageData.External_card === '')">
                 <h4 class="card-header">External Links &amp; Resources</h4>
                 <div [innerHTML]="pageData.External_card"></div>
             </section>

--- a/bcmi/src/app/static-pages/page/page.component.html
+++ b/bcmi/src/app/static-pages/page/page.component.html
@@ -11,9 +11,14 @@
 
 <div class="container" id="anchor-point">
     <div class="row">
-        <main class="col-lg-8" [innerHTML]="pageData.Content">
+        <main [ngClass]="{'col-lg-8': isTwoColumn}" [innerHTML]="pageData.Content">
         </main>
-        <aside class="col-lg-4">
+        <aside *ngIf="isTwoColumn" class="col-lg-4">
+            <section class="card" *ngIf="!(pageData.Ongoing_card === null ||  pageData.Ongoing_card === '')">
+                <h4 class="card-header">Ongoing Lifecycle Activities</h4>
+                <div [innerHTML]="pageData.Ongoing_card" class="card-body"></div>
+            </section>
+
             <section class="card" *ngIf="!(pageData.Related_card === null ||  pageData.Related_card === '')">
               <h4 class="card-header">Related Documents</h4>
                 <div [innerHTML]="pageData.Related_card" class="card-list"></div>

--- a/bcmi/src/app/static-pages/page/page.component.html
+++ b/bcmi/src/app/static-pages/page/page.component.html
@@ -1,0 +1,37 @@
+<div class="hero-banner">
+    <div class="container">
+        <div class="container__inner-container">
+            <div class="hero-banner__content">
+                <h1 id="pgTitle">{{pageData.Title}}</h1>
+                <p>{{pageData.Description}}</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="container" id="anchor-point">
+    <div class="row">
+        <main class="col-lg-8" [innerHTML]="pageData.Content">
+        </main>
+        <aside class="col-lg-4">
+            <section class="card">
+                <h4 class="card-header">Related Documents</h4>
+                <div [innerHTML]="pageData.Related_card" class="card-list"></div>
+            </section>
+            <section class="card">
+                <h4 class="card-header">External Links &amp; Resources</h4>
+                <div [innerHTML]="pageData.External_card"></div>
+            </section>
+
+            <!----
+            <section class="card">
+              <h4 class="card-header">Enforcement Actions</h4>
+              <ul class="nv-list">
+                  <<li><a href="/enforcement-actions" target="_blank" rel="noopener"> The Ministry of Energy, Mines, and Low Carbon Innovation </a></li>>
+              </ul>
+          </section>
+          --->
+
+        </aside>
+    </div>
+</div>

--- a/bcmi/src/app/static-pages/page/page.component.scss
+++ b/bcmi/src/app/static-pages/page/page.component.scss
@@ -1,0 +1,40 @@
+// Base
+@import "@assets/styles/base.scss";
+
+// Components
+@import "@assets/styles/components/aside.scss";
+@import "@assets/styles/components/card.scss";
+@import "@assets/styles/components/hero-banner.scss";
+@import "@assets/styles/components/feature-block.scss";
+@import "@assets/styles/components/lists.scss";
+
+
+.card-list {
+
+    ul {
+        margin: 0;
+        padding: 0;
+        list-style-type: none;
+
+        li {
+            @include clearfix();
+            margin-top: 1px;
+            padding: 0.5rem 1rem;
+            font-size: 0.9375rem;
+            background: $nv-list-bg;
+        }
+
+        span {
+            &.name,
+            &.value {
+                float: left;
+                display: block;
+                width: 50%;
+            }
+
+            &.name {
+                margin-bottom: 0.25rem;
+            }
+        }
+    }
+}

--- a/bcmi/src/app/static-pages/page/page.component.spec.ts
+++ b/bcmi/src/app/static-pages/page/page.component.spec.ts
@@ -2,7 +2,6 @@ import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PageComponent } from './page.component';
 import { ActivatedRoute } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { Page } from '@app/models/content/page';
 import { of } from 'rxjs';
 import { CommonModule } from '@angular/common';

--- a/bcmi/src/app/static-pages/page/page.component.spec.ts
+++ b/bcmi/src/app/static-pages/page/page.component.spec.ts
@@ -1,6 +1,11 @@
 import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PageComponent } from './page.component';
+import { ActivatedRoute } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Page } from '@app/models/content/page';
+import { of } from 'rxjs';
+import { CommonModule } from '@angular/common';
 
 window.scrollTo = jest.fn();
 
@@ -8,9 +13,16 @@ describe('PageComponent', () => {
   let component: PageComponent;
   let fixture: ComponentFixture<PageComponent>;
 
+  const pageData = new Page();
+  pageData.Title = "Test";
+
+  const fakeActivatedRoute = {data: of({pageData: [pageData]}) };
+
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ PageComponent ]
+      providers: [{provide: ActivatedRoute, useValue: fakeActivatedRoute}],
+      declarations: [PageComponent],
+      imports: [CommonModule]
     })
     .compileComponents();
   }));

--- a/bcmi/src/app/static-pages/page/page.component.spec.ts
+++ b/bcmi/src/app/static-pages/page/page.component.spec.ts
@@ -1,0 +1,27 @@
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PageComponent } from './page.component';
+
+window.scrollTo = jest.fn();
+
+describe('PageComponent', () => {
+  let component: PageComponent;
+  let fixture: ComponentFixture<PageComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ PageComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/bcmi/src/app/static-pages/page/page.component.ts
+++ b/bcmi/src/app/static-pages/page/page.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit, ViewEncapsulation } from '@angular/core';
-import { Page } from '../../models/content/page';
-import { Apollo, gql } from 'apollo-angular';
 import { ActivatedRoute } from '@angular/router';
+import { Page } from '../../models/content/page';
 
 @Component({
   selector: 'app-page',
@@ -12,6 +11,7 @@ import { ActivatedRoute } from '@angular/router';
 export class PageComponent implements OnInit {
 
   pageData: Page;
+  isTwoColumn: boolean;
 
   constructor(private activatedRoute: ActivatedRoute){};
 
@@ -20,6 +20,8 @@ export class PageComponent implements OnInit {
     this.activatedRoute.data.subscribe((response: any) => {
       this.pageData = response.pageData;
     })
+    // This conditional will need to be changed whenever sidecards are added to the template
+    this.isTwoColumn = !!this.pageData.External_card || !!this.pageData.Ongoing_card || !!this.pageData.Related_card;
     
   }
 

--- a/bcmi/src/app/static-pages/page/page.component.ts
+++ b/bcmi/src/app/static-pages/page/page.component.ts
@@ -1,0 +1,26 @@
+import { Component, OnInit, ViewEncapsulation } from '@angular/core';
+import { Page } from '../../models/content/page';
+import { Apollo, gql } from 'apollo-angular';
+import { ActivatedRoute } from '@angular/router';
+
+@Component({
+  selector: 'app-page',
+  templateUrl: './page.component.html',
+  styleUrls: ['./page.component.scss'],
+  encapsulation: ViewEncapsulation.None,
+})
+export class PageComponent implements OnInit {
+
+  pageData: Page;
+
+  constructor(private activatedRoute: ActivatedRoute){};
+
+  ngOnInit() {
+    //window.scrollTo(0, 0);
+    this.activatedRoute.data.subscribe((response: any) => {
+      this.pageData = response.pageData;
+    })
+    
+  }
+
+}

--- a/bcmi/src/app/static-pages/page/page.component.ts
+++ b/bcmi/src/app/static-pages/page/page.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 import { Page } from '../../models/content/page';
-import { Apollo, gql } from 'apollo-angular';
 import { ActivatedRoute } from '@angular/router';
 
 @Component({

--- a/bcmi/src/app/static-pages/tailings-management/tailings-management.component.html
+++ b/bcmi/src/app/static-pages/tailings-management/tailings-management.component.html
@@ -40,7 +40,7 @@
                   <li>Annual TSF Inspection (commonly called Dam Safety Inspection)</li>
                 </ul>
                 <p>The Ministry has prepared a <a href="https://nrs.objectstore.gov.bc.ca/lteczn/BCMI_DOCS/2022-TSF-Compliance-Status.pdf" target="_blank" rel="noopener">table of TSF-related compliance status</a> for metal and coal mines with one or more TSFs.</p>
-                <p>Visit the <a href="https://www.mines.nrs.gov.bc.ca/projects">site-specific pages on this website</a> to review Dam Safety Inspections.</p>
+                <p>Visit the <a href="https://www.mines.nrs.gov.bc.ca/mines">site-specific pages on this website</a> to review Dam Safety Inspections.</p>
             </section>
             <div class="content-links">
                 <a class="btn content-btn slide-l-btn" href="/topics-of-interest" [routerLink]="['/topics-of-interest']"><i class="material-icons">arrow_back</i><span>Back to Topics</span></a>

--- a/bcmi/tsconfig.json
+++ b/bcmi/tsconfig.json
@@ -1,5 +1,3 @@
-/* To learn more about Typescript configuration file: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
-/* To learn more about Angular compiler options: https://angular.dev/reference/configs/angular-compiler-options. */
 {
   "compileOnSave": false,
   "compilerOptions": {
@@ -7,14 +5,30 @@
     "strict": false,
     "baseUrl": "./src",
     "paths": {
-      "@app/*": ["app/*"],
-      "@models/*": ["app/models/*"],
-      "@map/*": ["app/map/*"],
-      "@assets/*": ["assets/*"],
-      "@pipes/*": ["app/pipes/*"],
-      "@projects/*": ["app/projects/*"],
-      "@services/*": ["app/services/*"],
-      "@shared/*": ["app/shared/*"],
+      "@app/*": [
+        "app/*"
+      ],
+      "@models/*": [
+        "app/models/*"
+      ],
+      "@map/*": [
+        "app/map/*"
+      ],
+      "@assets/*": [
+        "assets/*"
+      ],
+      "@pipes/*": [
+        "app/pipes/*"
+      ],
+      "@projects/*": [
+        "app/projects/*"
+      ],
+      "@services/*": [
+        "app/services/*"
+      ],
+      "@shared/*": [
+        "app/shared/*"
+      ]
     },
     "types": [
       "jest"
@@ -37,8 +51,10 @@
     "module": "ES2022",
     "lib": [
       "ES2022",
-      "dom"
-    ]
+      "dom",
+      "esnext.asynciterable"
+    ],
+    "allowSyntheticDefaultImports": true
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,

--- a/cms/.strapi-updater.json
+++ b/cms/.strapi-updater.json
@@ -1,4 +1,5 @@
 {
-	"latest": "4.25.10",
-	"lastUpdateCheck": 1725906248891
+	"latest": "5.0.1",
+	"lastUpdateCheck": 1727743835271,
+	"lastNotification": 1727454524118
 }

--- a/cms/.strapi/client/app.js
+++ b/cms/.strapi/client/app.js
@@ -4,6 +4,7 @@
  */
 import ckeditor5 from "@_sh/strapi-plugin-ckeditor/strapi-admin";
 import strapiCloud from "@strapi/plugin-cloud/strapi-admin";
+import graphql from "@strapi/plugin-graphql/strapi-admin";
 import i18N from "@strapi/plugin-i18n/strapi-admin";
 import usersPermissions from "@strapi/plugin-users-permissions/strapi-admin";
 import { renderAdmin } from "@strapi/strapi/admin";
@@ -16,6 +17,7 @@ renderAdmin(document.getElementById("strapi"), {
   plugins: {
     ckeditor5: ckeditor5,
     "strapi-cloud": strapiCloud,
+    graphql: graphql,
     i18n: i18N,
     "users-permissions": usersPermissions,
   },

--- a/cms/README.md
+++ b/cms/README.md
@@ -1,5 +1,19 @@
 # 🚀 Getting started with Strapi
 
+
+brew install postgresql
+brew services run postgresql
+psql postgres
+
+create user strapi with encrypted password 'strapi';
+create database cms owner strapi;
+
+.env file (Warning mac's may remove the .)
+
+Once Strapi is running you will need to enable read permissions on the Content types
+Settings > User & Permissions plugin > Roles > Public > Enable find and findOne for Page and others
+
+
 Strapi comes with a full featured [Command Line Interface](https://docs.strapi.io/dev-docs/cli) (CLI) which lets you scaffold and manage your project in seconds.
 
 ### `develop`

--- a/cms/package-lock.json
+++ b/cms/package-lock.json
@@ -1,16 +1,17 @@
 {
-  "name": "strap-2",
+  "name": "bcmi-cms",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "strap-2",
+      "name": "bcmi-cms",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@_sh/strapi-plugin-ckeditor": "^2.1.3",
         "@strapi/plugin-cloud": "4.25.10",
+        "@strapi/plugin-graphql": "^4.25.10",
         "@strapi/plugin-i18n": "4.25.10",
         "@strapi/plugin-users-permissions": "4.25.10",
         "@strapi/strapi": "4.25.10",
@@ -20,7 +21,6 @@
         "react-router-dom": "5.3.4",
         "styled-components": "5.3.3"
       },
-      "devDependencies": {},
       "engines": {
         "node": ">=18.0.0 <=20.x.x",
         "npm": ">=6.0.0"
@@ -95,6 +95,176 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@apollo/protobufjs": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.7.tgz",
+      "integrity": "sha512-Lahx5zntHPZia35myYDBRuF58tlwPskwHc5CWBZC/4bMKB6siTBWwtMrkqXcsNwQiFSzSx5hKdRPUmemrEp3Gg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "apollo-pbjs": "bin/pbjs",
+        "apollo-pbts": "bin/pbts"
+      }
+    },
+    "node_modules/@apollo/protobufjs/node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@apollo/usage-reporting-protobuf": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@apollo/usage-reporting-protobuf/-/usage-reporting-protobuf-4.1.1.tgz",
+      "integrity": "sha512-u40dIUePHaSKVshcedO7Wp+mPiZsaU6xjv9J+VyxpoU/zL6Jle+9zWeG98tr/+SZ0nZ4OXhrbb8SNr0rAPpIDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@apollo/protobufjs": "1.2.7"
+      }
+    },
+    "node_modules/@apollo/utils.dropunuseddefinitions": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.dropunuseddefinitions/-/utils.dropunuseddefinitions-1.1.0.tgz",
+      "integrity": "sha512-jU1XjMr6ec9pPoL+BFWzEPW7VHHulVdGKMkPAMiCigpVIT11VmCbnij0bWob8uS3ODJ65tZLYKAh/55vLw2rbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.keyvaluecache": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-1.0.2.tgz",
+      "integrity": "sha512-p7PVdLPMnPzmXSQVEsy27cYEjVON+SH/Wb7COyW3rQN8+wJgT1nv9jZouYtztWW8ZgTkii5T6tC9qfoDREd4mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apollo/utils.logger": "^1.0.0",
+        "lru-cache": "7.10.1 - 7.13.1"
+      }
+    },
+    "node_modules/@apollo/utils.keyvaluecache/node_modules/lru-cache": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.13.1.tgz",
+      "integrity": "sha512-CHqbAq7NFlW3RSnoWXLJBxCWaZVBrfa9UEHId2M3AW8iEBurbqduNexEUCGc3SHc6iCYXNJCDi903LajSVAEPQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@apollo/utils.logger": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-1.0.1.tgz",
+      "integrity": "sha512-XdlzoY7fYNK4OIcvMD2G94RoFZbzTQaNP0jozmqqMudmaGo2I/2Jx71xlDJ801mWA/mbYRihyaw6KJii7k5RVA==",
+      "license": "MIT"
+    },
+    "node_modules/@apollo/utils.printwithreducedwhitespace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.printwithreducedwhitespace/-/utils.printwithreducedwhitespace-1.1.0.tgz",
+      "integrity": "sha512-GfFSkAv3n1toDZ4V6u2d7L4xMwLA+lv+6hqXicMN9KELSJ9yy9RzuEXaX73c/Ry+GzRsBy/fdSUGayGqdHfT2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.removealiases": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.removealiases/-/utils.removealiases-1.0.0.tgz",
+      "integrity": "sha512-6cM8sEOJW2LaGjL/0vHV0GtRaSekrPQR4DiywaApQlL9EdROASZU5PsQibe2MWeZCOhNrPRuHh4wDMwPsWTn8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.sortast": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.sortast/-/utils.sortast-1.1.0.tgz",
+      "integrity": "sha512-VPlTsmUnOwzPK5yGZENN069y6uUHgeiSlpEhRnLFYwYNoJHsuJq2vXVwIaSmts015WTPa2fpz1inkLYByeuRQA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.sortby": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.stripsensitiveliterals": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.stripsensitiveliterals/-/utils.stripsensitiveliterals-1.2.0.tgz",
+      "integrity": "sha512-E41rDUzkz/cdikM5147d8nfCFVKovXxKBcjvLEQ7bjZm/cg9zEcXvS6vFY8ugTubI3fn6zoqo0CyU8zT+BGP9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.usagereporting": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.usagereporting/-/utils.usagereporting-1.0.1.tgz",
+      "integrity": "sha512-6dk+0hZlnDbahDBB2mP/PZ5ybrtCJdLMbeNJD+TJpKyZmSY6bA3SjI8Cr2EM9QA+AdziywuWg+SgbWUF3/zQqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@apollo/usage-reporting-protobuf": "^4.0.0",
+        "@apollo/utils.dropunuseddefinitions": "^1.1.0",
+        "@apollo/utils.printwithreducedwhitespace": "^1.1.0",
+        "@apollo/utils.removealiases": "1.0.0",
+        "@apollo/utils.sortast": "^1.1.0",
+        "@apollo/utils.stripsensitiveliterals": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollographql/apollo-tools": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.5.4.tgz",
+      "integrity": "sha512-shM3q7rUbNyXVVRkQJQseXv6bnYM3BUma/eZhwXR4xsuM+bqWnJKvW7SAfRjP7LuSCocrexa5AXhjjawNHrIlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "graphql": "^14.2.1 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@apollographql/graphql-playground-html": {
+      "version": "1.6.29",
+      "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.29.tgz",
+      "integrity": "sha512-xCcXpoz52rI4ksJSdOCxeOCn2DLocxwHf9dVT/Q90Pte1LX+LY+91SFtJF3KXVHH8kEin+g1KKCQPKBjZJfWNA==",
+      "license": "MIT",
+      "dependencies": {
+        "xss": "^1.0.8"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -3378,6 +3548,168 @@
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
       "license": "0BSD"
     },
+    "node_modules/@graphql-tools/merge": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.1.tgz",
+      "integrity": "sha512-BMm99mqdNZbEYeTPK3it9r9S6rsZsQKtlqJsSBknAclXq2pGEfOxjcIZi+kBSkHZKPKCRrYDd5vY0+rUmIHVLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/utils": "8.9.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/merge/node_modules/@graphql-tools/utils": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
+      "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/merge/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/@graphql-tools/mock": {
+      "version": "8.7.20",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/mock/-/mock-8.7.20.tgz",
+      "integrity": "sha512-ljcHSJWjC/ZyzpXd5cfNhPI7YljRVvabKHPzKjEs5ElxWu2cdlLGvyNYepApXDsM/OJG/2xuhGM+9GWu5gEAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/schema": "^9.0.18",
+        "@graphql-tools/utils": "^9.2.1",
+        "fast-json-stable-stringify": "^2.1.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/mock/node_modules/@graphql-tools/merge": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.4.2.tgz",
+      "integrity": "sha512-XbrHAaj8yDuINph+sAfuq3QCZ/tKblrTLOpirK0+CAgNlZUCHs0Fa+xtMUURgwCVThLle1AF7svJCxFizygLsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/utils": "^9.2.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/mock/node_modules/@graphql-tools/schema": {
+      "version": "9.0.19",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.19.tgz",
+      "integrity": "sha512-oBRPoNBtCkk0zbUsyP4GaIzCt8C0aCI4ycIRUL67KK5pOHljKLBBtGT+Jr6hkzA74C8Gco8bpZPe7aWFjiaK2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/merge": "^8.4.1",
+        "@graphql-tools/utils": "^9.2.1",
+        "tslib": "^2.4.0",
+        "value-or-promise": "^1.0.12"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/mock/node_modules/@graphql-tools/utils": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
+      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/mock/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/@graphql-tools/mock/node_modules/value-or-promise": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
+      "integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@graphql-tools/schema": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.5.1.tgz",
+      "integrity": "sha512-0Esilsh0P/qYcB5DKQpiKeQs/jevzIadNTaT0jeWklPMwNbT7yMX4EqZany7mbeRRlSRwMzNzL5olyFdffHBZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/merge": "8.3.1",
+        "@graphql-tools/utils": "8.9.0",
+        "tslib": "^2.4.0",
+        "value-or-promise": "1.0.11"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/schema/node_modules/@graphql-tools/utils": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.0.tgz",
+      "integrity": "sha512-pjJIWH0XOVnYGXCqej8g/u/tsfV4LvLlj0eATKQu5zwnxd/TiTHq7Cg313qUPTFFHZ3PP5wJ15chYVtLDwaymg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/schema/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/@graphql-tools/utils": {
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.13.1.tgz",
+      "integrity": "sha512-qIh9yYpdUFmctVqovwMdheVNJqFh+DQNWIhX87FJStfXYnmweBUDATok9fWPleKeFwxnW8IapKmY8m8toJEkAw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/utils/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/@hapi/bourne": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-3.0.0.tgz",
@@ -3497,6 +3829,12 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/@josephg/resolvable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@josephg/resolvable/-/resolvable-1.0.1.tgz",
+      "integrity": "sha512-CtzORUwWTTOTqfVtHaKRJ0I1kNQd1bpn3sUh8I3nJDVY+5/M/Oe1DnEWzPQvqq/xPIIkzzzIP7mfCoAjFRvDhg==",
+      "license": "ISC"
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.5",
@@ -3834,36 +4172,31 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
       "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
       "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -3873,36 +4206,31 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
       "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.0",
@@ -7441,6 +7769,42 @@
         "styled-components": "^5.2.1"
       }
     },
+    "node_modules/@strapi/plugin-graphql": {
+      "version": "4.25.10",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-graphql/-/plugin-graphql-4.25.10.tgz",
+      "integrity": "sha512-YWyJDy+FQ38vPZz4l4LxqBMklBew1gBrdIusAF7F2qGed09v6GOWjnfmgwBr7b7Sl3uAVQDhjGtKoutV5zlsjQ==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@graphql-tools/schema": "8.5.1",
+        "@graphql-tools/utils": "^8.13.1",
+        "@strapi/design-system": "1.19.0",
+        "@strapi/helper-plugin": "4.25.10",
+        "@strapi/icons": "1.19.0",
+        "@strapi/utils": "4.25.10",
+        "apollo-server-core": "3.12.1",
+        "apollo-server-koa": "3.10.0",
+        "graphql": "^15.5.1",
+        "graphql-depth-limit": "^1.1.0",
+        "graphql-playground-middleware-koa": "^1.6.21",
+        "graphql-scalars": "1.22.2",
+        "graphql-upload": "^13.0.0",
+        "koa-compose": "^4.1.0",
+        "lodash": "4.17.21",
+        "nexus": "1.3.0",
+        "pluralize": "8.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0 <=20.x.x",
+        "npm": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "@strapi/strapi": "^4.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "react-router-dom": "^5.2.0",
+        "styled-components": "^5.2.1"
+      }
+    },
     "node_modules/@strapi/plugin-i18n": {
       "version": "4.25.10",
       "resolved": "https://registry.npmjs.org/@strapi/plugin-i18n/-/plugin-i18n-4.25.10.tgz",
@@ -8173,6 +8537,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/@types/accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/argparse": {
       "version": "1.0.38",
       "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
@@ -8207,6 +8580,24 @@
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
       "license": "MIT",
       "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/content-disposition": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.8.tgz",
+      "integrity": "sha512-QVSSvno3dE0MgO76pJhmv4Qyi/j0Yk9pBp0Y7TJ2Tlj+KCgJWY6qX7nnxCOLkZ3VYRSIk1WTxCvwUSdx6CCLdg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/cookies": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.9.0.tgz",
+      "integrity": "sha512-40Zk8qR147RABiQ7NQnBzWzDcjKzNrntB5BAmeGCb2p/MIyOE+4BVvc17wumsUqUw00bJYqoXFHYygQnEFh4/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/express": "*",
+        "@types/keygrip": "*",
         "@types/node": "*"
       }
     },
@@ -8290,6 +8681,12 @@
       "integrity": "sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==",
       "license": "MIT"
     },
+    "node_modules/@types/http-assert": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.5.tgz",
+      "integrity": "sha512-4+tE/lwdAahgZT1g30Jkdm9PzFRde0xwxBNUyRsCitRvCQB90iuA2uJYdUnhnANRcqGXaWOGY4FEoxeElNAK2g==",
+      "license": "MIT"
+    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
@@ -8354,6 +8751,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/keygrip": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.6.tgz",
+      "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
@@ -8361,6 +8764,49 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/koa": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.15.0.tgz",
+      "integrity": "sha512-7QFsywoE5URbuVnG3loe03QXuGajrnotr3gQkXcEBShORai23MePfFYdhz90FEtBBpkyIYQbVD+evKtloCgX3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/accepts": "*",
+        "@types/content-disposition": "*",
+        "@types/cookies": "*",
+        "@types/http-assert": "*",
+        "@types/http-errors": "*",
+        "@types/keygrip": "*",
+        "@types/koa-compose": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/koa__cors": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/koa__cors/-/koa__cors-3.3.1.tgz",
+      "integrity": "sha512-aFGYhTFW7651KhmZZ05VG0QZJre7QxBxDj2LF1lf6GA/wSXEfKVAJxiQQWzRV4ZoMzQIO8vJBXKsUcRuvYK9qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/koa": "*"
+      }
+    },
+    "node_modules/@types/koa-bodyparser": {
+      "version": "4.3.12",
+      "resolved": "https://registry.npmjs.org/@types/koa-bodyparser/-/koa-bodyparser-4.3.12.tgz",
+      "integrity": "sha512-hKMmRMVP889gPIdLZmmtou/BijaU1tHPyMNmcK7FAHAdATnRcGQQy78EqTTxLH1D4FTsrxIzklAQCso9oGoebQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/koa": "*"
+      }
+    },
+    "node_modules/@types/koa-compose": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.8.tgz",
+      "integrity": "sha512-4Olc63RY+MKvxMwVknCUDhRQX1pFQoBZ/lXcRLP69PQkEpze/0cr8LNqJQe5NFb/b19DWi2a5bTi2VAlQzhJuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/koa": "*"
       }
     },
     "node_modules/@types/liftoff": {
@@ -8378,6 +8824,12 @@
       "version": "4.17.7",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.7.tgz",
       "integrity": "sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
       "license": "MIT"
     },
     "node_modules/@types/mime": {
@@ -9000,6 +9452,219 @@
         "node": ">= 8"
       }
     },
+    "node_modules/apollo-datasource": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-3.3.2.tgz",
+      "integrity": "sha512-L5TiS8E2Hn/Yz7SSnWIVbZw0ZfEIXZCa5VUiVxD9P53JvSrf4aStvsFDlGWPvpIdCR+aly2CfoB79B9/JjKFqg==",
+      "deprecated": "The `apollo-datasource` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023 and October 22nd 2024, respectively). See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
+      "license": "MIT",
+      "dependencies": {
+        "@apollo/utils.keyvaluecache": "^1.0.1",
+        "apollo-server-env": "^4.2.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/apollo-reporting-protobuf": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-3.4.0.tgz",
+      "integrity": "sha512-h0u3EbC/9RpihWOmcSsvTW2O6RXVaD/mPEjfrPkxRPTEPWqncsgOoRJw+wih4OqfH3PvTJvoEIf4LwKrUaqWog==",
+      "deprecated": "The `apollo-reporting-protobuf` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023 and October 22nd 2024, respectively). This package's functionality is now found in the `@apollo/usage-reporting-protobuf` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
+      "license": "MIT",
+      "dependencies": {
+        "@apollo/protobufjs": "1.2.6"
+      }
+    },
+    "node_modules/apollo-reporting-protobuf/node_modules/@apollo/protobufjs": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.6.tgz",
+      "integrity": "sha512-Wqo1oSHNUj/jxmsVp4iR3I480p6qdqHikn38lKrFhfzcDJ7lwd7Ck7cHRl4JE81tWNArl77xhnG/OkZhxKBYOw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.0",
+        "@types/node": "^10.1.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "apollo-pbjs": "bin/pbjs",
+        "apollo-pbts": "bin/pbts"
+      }
+    },
+    "node_modules/apollo-reporting-protobuf/node_modules/@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "license": "MIT"
+    },
+    "node_modules/apollo-reporting-protobuf/node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/apollo-server-core": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.12.1.tgz",
+      "integrity": "sha512-9SF5WAkkV0FZQ2HVUWI9Jada1U0jg7e8NCN9EklbtvaCeUlOLyXyM+KCWuZ7+dqHxjshbtcwylPHutt3uzoNkw==",
+      "deprecated": "The `apollo-server-core` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023 and October 22nd 2024, respectively). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
+      "license": "MIT",
+      "dependencies": {
+        "@apollo/utils.keyvaluecache": "^1.0.1",
+        "@apollo/utils.logger": "^1.0.0",
+        "@apollo/utils.usagereporting": "^1.0.0",
+        "@apollographql/apollo-tools": "^0.5.3",
+        "@apollographql/graphql-playground-html": "1.6.29",
+        "@graphql-tools/mock": "^8.1.2",
+        "@graphql-tools/schema": "^8.0.0",
+        "@josephg/resolvable": "^1.0.0",
+        "apollo-datasource": "^3.3.2",
+        "apollo-reporting-protobuf": "^3.4.0",
+        "apollo-server-env": "^4.2.1",
+        "apollo-server-errors": "^3.3.1",
+        "apollo-server-plugin-base": "^3.7.2",
+        "apollo-server-types": "^3.8.0",
+        "async-retry": "^1.2.1",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graphql-tag": "^2.11.0",
+        "loglevel": "^1.6.8",
+        "lru-cache": "^6.0.0",
+        "node-abort-controller": "^3.0.1",
+        "sha.js": "^2.4.11",
+        "uuid": "^9.0.0",
+        "whatwg-mimetype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.3.0 || ^16.0.0"
+      }
+    },
+    "node_modules/apollo-server-core/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/apollo-server-env": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-4.2.1.tgz",
+      "integrity": "sha512-vm/7c7ld+zFMxibzqZ7SSa5tBENc4B0uye9LTfjJwGoQFY5xsUPH5FpO5j0bMUDZ8YYNbrF9SNtzc5Cngcr90g==",
+      "deprecated": "The `apollo-server-env` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023 and October 22nd 2024, respectively). This package's functionality is now found in the `@apollo/utils.fetcher` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.7"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/apollo-server-errors": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-3.3.1.tgz",
+      "integrity": "sha512-xnZJ5QWs6FixHICXHxUfm+ZWqqxrNuPlQ+kj5m6RtEgIpekOPssH/SD9gf2B4HuWV0QozorrygwZnux8POvyPA==",
+      "deprecated": "The `apollo-server-errors` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023 and October 22nd 2024, respectively). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.3.0 || ^16.0.0"
+      }
+    },
+    "node_modules/apollo-server-koa": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-koa/-/apollo-server-koa-3.10.0.tgz",
+      "integrity": "sha512-OHaQRz0vvsALT2q+j4uWnCLRrUl1sM0H6JZvB2PfQwANsjTdwm2Eo6FO5etVByvrU4K1iXD6wBWid0Fjk0/OMQ==",
+      "deprecated": "The `apollo-server-koa` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023 and October 22nd 2024, respectively). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
+      "license": "MIT",
+      "dependencies": {
+        "@koa/cors": "^3.1.0",
+        "@types/accepts": "^1.3.5",
+        "@types/koa": "^2.11.6",
+        "@types/koa__cors": "^3.0.1",
+        "@types/koa-bodyparser": "^4.3.0",
+        "@types/koa-compose": "^3.2.5",
+        "accepts": "^1.3.7",
+        "apollo-server-core": "^3.10.0",
+        "apollo-server-types": "^3.6.2",
+        "koa-bodyparser": "^4.3.0",
+        "koa-compose": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.3.0 || ^16.0.0",
+        "koa": "^2.13.1"
+      }
+    },
+    "node_modules/apollo-server-koa/node_modules/@koa/cors": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-3.4.3.tgz",
+      "integrity": "sha512-WPXQUaAeAMVaLTEFpoq3T2O1C+FstkjJnDQqy95Ck1UdILajsRhu6mhJ8H2f4NFPRBoCNN+qywTJfq/gGki5mw==",
+      "license": "MIT",
+      "dependencies": {
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/apollo-server-plugin-base": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-3.7.2.tgz",
+      "integrity": "sha512-wE8dwGDvBOGehSsPTRZ8P/33Jan6/PmL0y0aN/1Z5a5GcbFhDaaJCjK5cav6npbbGL2DPKK0r6MPXi3k3N45aw==",
+      "deprecated": "The `apollo-server-plugin-base` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023 and October 22nd 2024, respectively). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
+      "license": "MIT",
+      "dependencies": {
+        "apollo-server-types": "^3.8.0"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.3.0 || ^16.0.0"
+      }
+    },
+    "node_modules/apollo-server-types": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.8.0.tgz",
+      "integrity": "sha512-ZI/8rTE4ww8BHktsVpb91Sdq7Cb71rdSkXELSwdSR0eXu600/sY+1UXhTWdiJvk+Eq5ljqoHLwLbY2+Clq2b9A==",
+      "deprecated": "The `apollo-server-types` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023 and October 22nd 2024, respectively). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
+      "license": "MIT",
+      "dependencies": {
+        "@apollo/utils.keyvaluecache": "^1.0.1",
+        "@apollo/utils.logger": "^1.0.0",
+        "apollo-reporting-protobuf": "^3.4.0",
+        "apollo-server-env": "^4.2.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.3.0 || ^16.0.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -9087,6 +9752,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/asn1.js": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
@@ -9113,6 +9787,15 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -9608,6 +10291,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
+      "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
+      "dependencies": {
+        "dicer": "0.3.0"
+      },
+      "engines": {
+        "node": ">=4.5.0"
       }
     },
     "node_modules/byte-size": {
@@ -10902,6 +11596,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -11323,6 +12023,17 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/dicer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
+      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
+      "dependencies": {
+        "streamsearch": "0.1.2"
+      },
+      "engines": {
+        "node": ">=4.5.0"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -12985,6 +13696,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-capacitor": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-6.2.0.tgz",
+      "integrity": "sha512-nKcE1UduoSKX27NSZlg879LdQc94OtbOsEmKMN2MBNudXREvijRKx2GEBsTMTfws+BrbkJoEuynbGSVRSpauvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -13583,6 +14303,114 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graphql": {
+      "version": "15.9.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.9.0.tgz",
+      "integrity": "sha512-GCOQdvm7XxV1S4U4CGrsdlEN37245eC8P9zaYCMr6K1BG0IPGy5lUwmJsEOGyl1GD6HXjOtl2keCP9asRBwNvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/graphql-depth-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-depth-limit/-/graphql-depth-limit-1.1.0.tgz",
+      "integrity": "sha512-+3B2BaG8qQ8E18kzk9yiSdAa75i/hnnOwgSeAxVJctGQPvmeiLtqKOYF6HETCyRjiF7Xfsyal0HbLlxCQkgkrw==",
+      "license": "MIT",
+      "dependencies": {
+        "arrify": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "*"
+      }
+    },
+    "node_modules/graphql-playground-html": {
+      "version": "1.6.30",
+      "resolved": "https://registry.npmjs.org/graphql-playground-html/-/graphql-playground-html-1.6.30.tgz",
+      "integrity": "sha512-tpCujhsJMva4aqE8ULnF7/l3xw4sNRZcSHu+R00VV+W0mfp+Q20Plvcrp+5UXD+2yS6oyCXncA+zoQJQqhGCEw==",
+      "license": "MIT",
+      "dependencies": {
+        "xss": "^1.0.6"
+      }
+    },
+    "node_modules/graphql-playground-middleware-koa": {
+      "version": "1.6.22",
+      "resolved": "https://registry.npmjs.org/graphql-playground-middleware-koa/-/graphql-playground-middleware-koa-1.6.22.tgz",
+      "integrity": "sha512-soVUM76ecq5GHk12H69Ce7afzbYuWWc73oKMOcEkmtAn/G9NUdsNvLjLdCnHQX1V0cOUeSbmcYcrebyBOIYGMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graphql-playground-html": "^1.6.30"
+      },
+      "peerDependencies": {
+        "koa": "^2"
+      }
+    },
+    "node_modules/graphql-scalars": {
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/graphql-scalars/-/graphql-scalars-1.22.2.tgz",
+      "integrity": "sha512-my9FB4GtghqXqi/lWSVAOPiTzTnnEzdOXCsAC2bb5V7EFNQjVjwy3cSSbUvgYOtDuDibd+ZsCDhz+4eykYOlhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/graphql-scalars/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/graphql-tag": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/graphql-tag/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/graphql-upload": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-13.0.0.tgz",
+      "integrity": "sha512-YKhx8m/uOtKu4Y1UzBFJhbBGJTlk7k4CydlUUiNrtxnwZv0WigbRHP+DVhRNKt7u7DXOtcKZeYJlGtnMXvreXA==",
+      "license": "MIT",
+      "dependencies": {
+        "busboy": "^0.3.1",
+        "fs-capacitor": "^6.2.0",
+        "http-errors": "^1.8.1",
+        "object-path": "^0.11.8"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >= 16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jaydenseric"
+      },
+      "peerDependencies": {
+        "graphql": "0.13.1 - 16"
       }
     },
     "node_modules/gzip-size": {
@@ -14761,6 +15589,12 @@
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
       "license": "MIT"
     },
+    "node_modules/iterall": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
+      "license": "MIT"
+    },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -15528,6 +16362,12 @@
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "license": "MIT"
     },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+      "license": "MIT"
+    },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -15568,6 +16408,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
     "node_modules/long": {
@@ -16308,6 +17161,25 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "license": "MIT"
     },
+    "node_modules/nexus": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/nexus/-/nexus-1.3.0.tgz",
+      "integrity": "sha512-w/s19OiNOs0LrtP7pBmD9/FqJHvZLmCipVRt6v1PM8cRUYIbhEswyNKGHVoC4eHZGPSnD+bOf5A3+gnbt0A5/A==",
+      "license": "MIT",
+      "dependencies": {
+        "iterall": "^1.3.0",
+        "tslib": "^2.0.3"
+      },
+      "peerDependencies": {
+        "graphql": "15.x || 16.x"
+      }
+    },
+    "node_modules/nexus/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
     "node_modules/no-case": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
@@ -16774,6 +17646,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-path": {
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.8.tgz",
+      "integrity": "sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.12.0"
       }
     },
     "node_modules/object-visit": {
@@ -19283,6 +20164,15 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -19737,6 +20627,19 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      }
     },
     "node_modules/shallowequal": {
       "version": "1.1.0",
@@ -20476,6 +21379,14 @@
       "resolved": "https://registry.npmjs.org/stream-slice/-/stream-slice-0.1.2.tgz",
       "integrity": "sha512-QzQxpoacatkreL6jsxnVb7X5R/pGw9OUv2qWTYWnmLpg4NdN31snPy/f3TdQE1ZUXaThRvj1Zw4/OGg0ZkaLMA==",
       "license": "MIT"
+    },
+    "node_modules/streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha512-jos8u++JKm0ARcSUTAZXOVC0mSox7Bhn6sBgty73P1f3JGf7yG2clTbBNHUdde/kdvP2FESam+vM6l8jBrNxHA==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/streamx": {
       "version": "2.20.0",
@@ -21703,6 +22614,15 @@
       "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
       "license": "MIT"
     },
+    "node_modules/value-or-promise": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.11.tgz",
+      "integrity": "sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/vanilla-colorful": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/vanilla-colorful/-/vanilla-colorful-0.7.2.tgz",
@@ -22046,6 +22966,15 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -22292,6 +23221,28 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/xss": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.15.tgz",
+      "integrity": "sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      },
+      "bin": {
+        "xss": "bin/xss"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/xss/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/cms/package.json
+++ b/cms/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@_sh/strapi-plugin-ckeditor": "^2.1.3",
     "@strapi/plugin-cloud": "4.25.10",
+    "@strapi/plugin-graphql": "^4.25.10",
     "@strapi/plugin-i18n": "4.25.10",
     "@strapi/plugin-users-permissions": "4.25.10",
     "@strapi/strapi": "4.25.10",

--- a/cms/src/api/navigation/content-types/navigation/schema.json
+++ b/cms/src/api/navigation/content-types/navigation/schema.json
@@ -1,0 +1,26 @@
+{
+  "kind": "collectionType",
+  "collectionName": "navigations",
+  "info": {
+    "singularName": "navigation",
+    "pluralName": "navigations",
+    "displayName": "Navigation"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "Name": {
+      "type": "string"
+    },
+    "defaultRoute": {
+      "type": "string"
+    },
+    "pages": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::page.page"
+    }
+  }
+}

--- a/cms/src/api/navigation/controllers/navigation.ts
+++ b/cms/src/api/navigation/controllers/navigation.ts
@@ -1,0 +1,7 @@
+/**
+ * navigation controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::navigation.navigation');

--- a/cms/src/api/navigation/routes/navigation.ts
+++ b/cms/src/api/navigation/routes/navigation.ts
@@ -1,0 +1,7 @@
+/**
+ * navigation router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::navigation.navigation');

--- a/cms/src/api/navigation/services/navigation.ts
+++ b/cms/src/api/navigation/services/navigation.ts
@@ -1,0 +1,7 @@
+/**
+ * navigation service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::navigation.navigation');

--- a/cms/src/api/page/content-types/page/schema.json
+++ b/cms/src/api/page/content-types/page/schema.json
@@ -51,10 +51,18 @@
       "customField": "plugin::ckeditor5.CKEditor"
     },
     "route": {
-      "type": "string"
+      "type": "string",
+      "required": true
     },
     "tooltip": {
       "type": "text"
+    },
+    "Enforcement_card": {
+      "type": "customField",
+      "options": {
+        "preset": "toolbar"
+      },
+      "customField": "plugin::ckeditor5.CKEditor"
     }
   }
 }

--- a/cms/src/api/page/content-types/page/schema.json
+++ b/cms/src/api/page/content-types/page/schema.json
@@ -4,7 +4,8 @@
   "info": {
     "singularName": "page",
     "pluralName": "pages",
-    "displayName": "Page"
+    "displayName": "Page",
+    "description": ""
   },
   "options": {
     "draftAndPublish": true
@@ -48,6 +49,12 @@
         "preset": "toolbar"
       },
       "customField": "plugin::ckeditor5.CKEditor"
+    },
+    "route": {
+      "type": "string"
+    },
+    "tooltip": {
+      "type": "text"
     }
   }
 }

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -5,7 +5,37 @@ export default {
    *
    * This gives you an opportunity to extend code.
    */
-  register(/*{ strapi }*/) {},
+  register({ strapi }) {
+    const extensionService = strapi.service("plugin::graphql.extension");
+    extensionService.use(({ strapi }) => ({
+      typeDefs: `
+        type Query {
+          pageByRoute(route: String!): PageEntityResponse
+        }
+      `,
+      resolvers: {
+        Query: {
+          pageByRoute: {
+            resolve: async (parent, args, context) => {
+              const { toEntityResponse } = strapi.service(
+                "plugin::graphql.format"
+              ).returnTypes;
+              const data = await strapi.services["api::page.page"].find({
+                filters: {route: args.route},
+              });
+              const response = toEntityResponse(data.results[0]);
+              return response;
+            }
+          }
+        }
+      },
+      resolversConfig: {
+        "Query.pageByRoute": {
+          auth: false,
+        }
+      }
+    }));
+  },
 
   /**
    * An asynchronous bootstrap function that runs before

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -922,8 +922,15 @@ export interface ApiPagePage extends Schema.CollectionType {
           preset: 'toolbar';
         }
       >;
-    route: Attribute.String;
+    route: Attribute.String & Attribute.Required;
     tooltip: Attribute.Text;
+    Enforcement_card: Attribute.RichText &
+      Attribute.CustomField<
+        'plugin::ckeditor5.CKEditor',
+        {
+          preset: 'toolbar';
+        }
+      >;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -844,12 +844,48 @@ export interface ApiHomeHome extends Schema.SingleType {
   };
 }
 
+export interface ApiNavigationNavigation extends Schema.CollectionType {
+  collectionName: 'navigations';
+  info: {
+    singularName: 'navigation';
+    pluralName: 'navigations';
+    displayName: 'Navigation';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    Name: Attribute.String;
+    defaultRoute: Attribute.String;
+    pages: Attribute.Relation<
+      'api::navigation.navigation',
+      'oneToMany',
+      'api::page.page'
+    >;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::navigation.navigation',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::navigation.navigation',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
 export interface ApiPagePage extends Schema.CollectionType {
   collectionName: 'pages';
   info: {
     singularName: 'page';
     pluralName: 'pages';
     displayName: 'Page';
+    description: '';
   };
   options: {
     draftAndPublish: true;
@@ -886,6 +922,8 @@ export interface ApiPagePage extends Schema.CollectionType {
           preset: 'toolbar';
         }
       >;
+    route: Attribute.String;
+    tooltip: Attribute.Text;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;
@@ -916,6 +954,7 @@ declare module '@strapi/types' {
       'plugin::users-permissions.user': PluginUsersPermissionsUser;
       'api::fast-fact.fast-fact': ApiFastFactFastFact;
       'api::home.home': ApiHomeHome;
+      'api::navigation.navigation': ApiNavigationNavigation;
       'api::page.page': ApiPagePage;
     }
   }

--- a/functional-tests/src/test/groovy/pages/app/ProjectsPage.groovy
+++ b/functional-tests/src/test/groovy/pages/app/ProjectsPage.groovy
@@ -4,7 +4,7 @@ import pages.base.BaseAppPage
 
 class ProjectsPage extends BaseAppPage {
   static at = { pageTitle.equals("Find Mines in British Columbia") }
-  static url = "/projects"
+  static url = "/mines"
   static content = {
     pageTitle { $("#pgTitle").text() }
     HomeBtn { $("#header .brand") }


### PR DESCRIPTION
- Added the GraphQL plugin to Strapi + Apollo Angular for making GraphQL requests
- Wrote ContentResolver to fetch and return page content for the currently requested route
- Changed the /projects endpoint to /mines
- Started the 'page' template, with some conditional rendering of the sidebars.
- Added dynamic generation of angular routes (in ConfigService) based on the routes entered in the CMS.