### PR TITLE
[BCMI-419] Fix partial routes and migrate some missing page content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ npm-debug.log
 testem.log
 /typings
 
+# Secrets
+/cms/.env
+
 # e2e
 /build
 

--- a/bcmi/src/app/app.module.ts
+++ b/bcmi/src/app/app.module.ts
@@ -38,6 +38,7 @@ import { LeafletModule } from '@bluehalo/ngx-leaflet';
 import { GraphQLModule } from './graphql.module';
 import { PageComponent } from './static-pages/page/page.component';
 import { ContentService } from './services/content-service';
+import { ContentDirective } from './services/content-directive';
 
 export function initConfig(configService: ConfigService) {
   return () => configService.init();
@@ -57,7 +58,8 @@ export function initConfig(configService: ConfigService) {
     WaterQualityComponent,
     TailingsManagementComponent,
     ReclamationComponent,
-    NotFoundComponent
+    NotFoundComponent,
+    ContentDirective
   ],
   imports: [
     TagInputModule,

--- a/bcmi/src/app/app.routes.ts
+++ b/bcmi/src/app/app.routes.ts
@@ -1,23 +1,13 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
-import { ContactComponent } from './static-pages/contact/contact.component';
 import { HomeComponent } from './home/home.component';
 import { MainMapComponent } from './map/main-map/main-map.component';
 import { NotFoundComponent } from './not-found/not-found.component';
-import { LifecycleComponent } from './static-pages/lifecycle/lifecycle.component';
 
 export const routes: Routes = [
   {
     path: '',
     component: HomeComponent
-  },
-  {
-    path: 'contact',
-    component: ContactComponent,
-  },
-  {
-    path: 'lifecycle2',
-    component: LifecycleComponent,
   },
   {
     path: 'map',

--- a/bcmi/src/app/app.routes.ts
+++ b/bcmi/src/app/app.routes.ts
@@ -1,60 +1,14 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
-import { AuthorizationsComponent } from './static-pages/authorizations/authorizations.component';
-//import { ComplianceOversightComponent } from './static-pages/compliance-oversight/compliance-oversight.component';
 import { ContactComponent } from './static-pages/contact/contact.component';
 import { HomeComponent } from './home/home.component';
-//import { LegislationComponent } from './static-pages/legislation/legislation.component';
-//import { LifecycleComponent } from './static-pages/lifecycle/lifecycle.component';
-import { ReclamationComponent } from './static-pages/reclamation/reclamation.component';
-import { TailingsManagementComponent } from './static-pages/tailings-management/tailings-management.component';
-import { TopicsOfInterestComponent } from './static-pages/topics-of-interest/topics-of-interest.component';
-import { WaterQualityComponent } from './static-pages/water-quality/water-quality.component';
 import { MainMapComponent } from './map/main-map/main-map.component';
 import { NotFoundComponent } from './not-found/not-found.component';
 
 export const routes: Routes = [
   {
-    path: 'authorizations',
-    component: AuthorizationsComponent
-  },
-  /* Commenting out for demo
-  {
-    path: 'compliance-oversight',
-    component: ComplianceOversightComponent
-  },
-  */
-  {
     path: '',
     component: HomeComponent
-  },
-  /* Commenting out for demo
-  {
-    path: 'legislation',
-    component: LegislationComponent
-  },
-  */
-  /* Commenting out for demo
-  {
-    path: 'lifecycle',
-    component: LifecycleComponent
-  },
-  */
-  {
-    path: 'reclamation',
-    component: ReclamationComponent
-  },
-  {
-    path: 'tailings-management',
-    component: TailingsManagementComponent
-  },
-  {
-    path: 'topics-of-interest',
-    component: TopicsOfInterestComponent
-  },
-  {
-    path: 'water-quality',
-    component: WaterQualityComponent
   },
   {
     path: 'contact',

--- a/bcmi/src/app/app.routes.ts
+++ b/bcmi/src/app/app.routes.ts
@@ -4,6 +4,7 @@ import { ContactComponent } from './static-pages/contact/contact.component';
 import { HomeComponent } from './home/home.component';
 import { MainMapComponent } from './map/main-map/main-map.component';
 import { NotFoundComponent } from './not-found/not-found.component';
+import { LifecycleComponent } from './static-pages/lifecycle/lifecycle.component';
 
 export const routes: Routes = [
   {
@@ -13,6 +14,10 @@ export const routes: Routes = [
   {
     path: 'contact',
     component: ContactComponent,
+  },
+  {
+    path: 'lifecycle2',
+    component: LifecycleComponent,
   },
   {
     path: 'map',

--- a/bcmi/src/app/models/content/header_button.ts
+++ b/bcmi/src/app/models/content/header_button.ts
@@ -1,0 +1,4 @@
+export class Header_Button {
+    Text: string;
+    Section_id: string;
+}

--- a/bcmi/src/app/models/content/page.ts
+++ b/bcmi/src/app/models/content/page.ts
@@ -1,7 +1,10 @@
+import { Header_Button } from "./header_button"
+
 // When adding new properties to this class, edit the query in /src/app/services/content-resolver.ts to include the new property
 export class Page {
     Title: string
     Description: string
+    Header_button: Header_Button[] // strapi doesn't allow renaming :( I wish I could add an s
     Content: string
     // If you're adding a new sidecard variable, please add it to the isTwoColumn conditional as well!
     Ongoing_card: string

--- a/bcmi/src/app/models/content/page.ts
+++ b/bcmi/src/app/models/content/page.ts
@@ -1,10 +1,13 @@
+// When adding new properties to this class, edit the query in /src/app/services/content-resolver.ts to include the new property
 export class Page {
     Title: string
     Description: string
     Content: string
+    // If you're adding a new sidecard variable, please add it to the isTwoColumn conditional as well!
     Ongoing_card: string
     External_card: string
     Related_card: string
+    Enforcement_Actions_card: string
     route: string
     tooltip: string
   }

--- a/bcmi/src/app/services/content-directive.ts
+++ b/bcmi/src/app/services/content-directive.ts
@@ -1,0 +1,39 @@
+import { Directive, ElementRef, Input, Renderer2, ViewContainerRef } from "@angular/core";
+import { DynamicLinkComponent } from "@app/shared/dynamic-link";
+
+@Directive({
+    selector: "[content]",
+})
+
+export class ContentDirective {
+    @Input()
+    appStyle: boolean = true;
+    constructor(
+        private ref: ElementRef,
+        private viewContainerRef: ViewContainerRef,
+        private renderer: Renderer2,
+    ) {}
+
+    ngAfterViewInit() {
+        let elements = Array.from(this.ref.nativeElement.getElementsByTagName("a"));
+        if(elements.length){
+            elements.forEach( (link: HTMLAnchorElement) => {
+                if(link.hasAttribute("href") && link.getAttribute("href")[0] == '/'){
+                    this.replaceLink(link,link.getAttribute("href"));
+                }
+            })
+        }
+    }
+    private replaceLink(anchor: HTMLAnchorElement, href: string) {
+        // Create a new component dynamically
+        const componentRef = this.viewContainerRef.createComponent(DynamicLinkComponent);
+        componentRef.instance.routerLink = href;
+        componentRef.instance.linkHTML = anchor.innerHTML;
+        componentRef.instance.linkClass = anchor.className;
+
+        // Append the newly created component and destroy the old one
+        this.renderer.insertBefore(anchor.parentElement, componentRef.location.nativeElement,anchor);
+        this.renderer.removeChild(this.ref.nativeElement, anchor);
+      }
+    
+}

--- a/bcmi/src/app/services/content-directive.ts
+++ b/bcmi/src/app/services/content-directive.ts
@@ -1,13 +1,13 @@
-import { Directive, ElementRef, Input, Renderer2, ViewContainerRef } from "@angular/core";
+import { Directive, ElementRef, Input, Renderer2, ViewContainerRef, AfterViewInit } from "@angular/core";
 import { DynamicLinkComponent } from "@app/shared/dynamic-link";
 
 @Directive({
-    selector: "[content]",
+    selector: "[appContent]",
 })
 
-export class ContentDirective {
+export class ContentDirective implements AfterViewInit {
     @Input()
-    appStyle: boolean = true;
+    appStyle = true;
     constructor(
         private ref: ElementRef,
         private viewContainerRef: ViewContainerRef,

--- a/bcmi/src/app/services/content-directive.ts
+++ b/bcmi/src/app/services/content-directive.ts
@@ -15,7 +15,7 @@ export class ContentDirective {
     ) {}
 
     ngAfterViewInit() {
-        let elements = Array.from(this.ref.nativeElement.getElementsByTagName("a"));
+        const elements = Array.from(this.ref.nativeElement.getElementsByTagName("a"));
         if(elements.length){
             elements.forEach( (link: HTMLAnchorElement) => {
                 if(link.hasAttribute("href") && link.getAttribute("href")[0] == '/'){
@@ -25,9 +25,18 @@ export class ContentDirective {
         }
     }
     private replaceLink(anchor: HTMLAnchorElement, href: string) {
+        let processedHref = href;
         // Create a new component dynamically
         const componentRef = this.viewContainerRef.createComponent(DynamicLinkComponent);
-        componentRef.instance.routerLink = href;
+
+        // Handle fragment if the link has one
+        const hashtagIndex = href.indexOf('#');
+        if (hashtagIndex != -1) {
+            processedHref = href.substring(0, hashtagIndex);
+            componentRef.instance.fragment = href.substring(hashtagIndex + 1);
+        }
+
+        componentRef.instance.routerLink = processedHref;
         componentRef.instance.linkHTML = anchor.innerHTML;
         componentRef.instance.linkClass = anchor.className;
 

--- a/bcmi/src/app/services/content-resolver.ts
+++ b/bcmi/src/app/services/content-resolver.ts
@@ -13,6 +13,7 @@ export class ContentResolver implements Resolve<Page> {
 
     private getPage = function(route){
 
+    // When adding new properties to the Page class, edit this query
     return gql`
     {
         pageByRoute(route: "${route}") {
@@ -24,6 +25,7 @@ export class ContentResolver implements Resolve<Page> {
                     Ongoing_card
                     External_card
                     Related_card
+                    Enforcement_Actions_card
                     route
                     tooltip
                 }

--- a/bcmi/src/app/services/content-resolver.ts
+++ b/bcmi/src/app/services/content-resolver.ts
@@ -21,6 +21,10 @@ export class ContentResolver implements Resolve<Page> {
                 attributes{
                     Title,
                     Description
+                    Header_button{
+                      Text
+                      Section_id
+                    }
                     Content
                     Ongoing_card
                     External_card

--- a/bcmi/src/app/shared/dynamic-link.ts
+++ b/bcmi/src/app/shared/dynamic-link.ts
@@ -1,0 +1,14 @@
+import { Component, Input } from '@angular/core';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-dynamic-link',
+  template: `<a [routerLink]="routerLink" [innerHTML]="linkHTML" [ngClass]="linkClass"></a>`,
+})
+export class DynamicLinkComponent {
+  @Input() routerLink: string;
+  @Input() linkHTML: string;
+  @Input() linkClass: string;
+
+  constructor(private router: Router) {}
+}

--- a/bcmi/src/app/shared/dynamic-link.ts
+++ b/bcmi/src/app/shared/dynamic-link.ts
@@ -3,10 +3,11 @@ import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-dynamic-link',
-  template: `<a [routerLink]="routerLink" [innerHTML]="linkHTML" [ngClass]="linkClass"></a>`,
+  template: `<a [routerLink]="routerLink" [fragment]="fragment"[innerHTML]="linkHTML" [ngClass]="linkClass"></a>`,
 })
 export class DynamicLinkComponent {
   @Input() routerLink: string;
+  @Input() fragment:string | undefined;
   @Input() linkHTML: string;
   @Input() linkClass: string;
 

--- a/bcmi/src/app/shared/dynamic-link.ts
+++ b/bcmi/src/app/shared/dynamic-link.ts
@@ -3,7 +3,7 @@ import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-dynamic-link',
-  template: `<a [routerLink]="routerLink" [fragment]="fragment"[innerHTML]="linkHTML" [ngClass]="linkClass"></a>`,
+  template: `<a [routerLink]="routerLink" [fragment]="fragment" [innerHTML]="linkHTML" [ngClass]="linkClass"></a>`,
 })
 export class DynamicLinkComponent {
   @Input() routerLink: string;

--- a/bcmi/src/app/shared/shared.module.ts
+++ b/bcmi/src/app/shared/shared.module.ts
@@ -7,6 +7,7 @@ import { ProjectStatusFilterPipe } from '@pipes/project-status-filter.pipe';
 import { RemoveStringValuePipe } from '@pipes/remove-string-value.pipe';
 import { SafeHtmlPipe } from '@pipes/safe-html.pipe';
 import { RouterModule } from '@angular/router';
+import { DynamicLinkComponent } from './dynamic-link';
 
 @NgModule({
   imports: [
@@ -19,7 +20,8 @@ import { RouterModule } from '@angular/router';
     ProjectTypeFilterPipe,
     ProjectStatusFilterPipe,
     RemoveStringValuePipe,
-    SafeHtmlPipe
+    SafeHtmlPipe,
+    DynamicLinkComponent
   ],
   exports: [
     ObjectFilterPipe,

--- a/bcmi/src/app/static-pages/page/page.component.html
+++ b/bcmi/src/app/static-pages/page/page.component.html
@@ -11,7 +11,7 @@
 
 <div class="container" id="anchor-point">
     <div class="row">
-        <main [ngClass]="{'col-lg-8': isTwoColumn}" content [innerHTML]="pageData.Content">
+        <main id="page-content" [ngClass]="{'col-lg-8': isTwoColumn}" content [innerHTML]="pageData.Content">
         </main>
         <aside *ngIf="isTwoColumn" class="col-lg-4">
             <section class="card" *ngIf="!(pageData.Ongoing_card === null ||  pageData.Ongoing_card === '')">

--- a/bcmi/src/app/static-pages/page/page.component.html
+++ b/bcmi/src/app/static-pages/page/page.component.html
@@ -11,27 +11,27 @@
 
 <div class="container" id="anchor-point">
     <div class="row">
-        <main [ngClass]="{'col-lg-8': isTwoColumn}" [innerHTML]="pageData.Content">
+        <main [ngClass]="{'col-lg-8': isTwoColumn}" content [innerHTML]="pageData.Content">
         </main>
         <aside *ngIf="isTwoColumn" class="col-lg-4">
             <section class="card" *ngIf="!(pageData.Ongoing_card === null ||  pageData.Ongoing_card === '')">
                 <h4 class="card-header">Ongoing Lifecycle Activities</h4>
-                <div [innerHTML]="pageData.Ongoing_card" class="card-body"></div>
+                <div content [innerHTML]="pageData.Ongoing_card" class="card-body"></div>
             </section>
 
             <section class="card" *ngIf="!(pageData.Related_card === null ||  pageData.Related_card === '')">
               <h4 class="card-header">Related Documents</h4>
-                <div [innerHTML]="pageData.Related_card" class="card-list"></div>
+                <div content [innerHTML]="pageData.Related_card" class="card-list"></div>
             </section>
 
             <section class="card" *ngIf="!(pageData.External_card === null ||  pageData.External_card === '')">
                 <h4 class="card-header">External Links &amp; Resources</h4>
-                <div [innerHTML]="pageData.External_card"></div>
+                <div content [innerHTML]="pageData.External_card"></div>
             </section>
 
             <section class="card" *ngIf="!(pageData.Enforcement_Actions_card === null ||  pageData.Enforcement_Actions_card === '')">
               <h4 class="card-header">Enforcement Actions</h4>
-              <div [innerHTML]="pageData.Enforcement_Actions_card"></div>
+              <div content [innerHTML]="pageData.Enforcement_Actions_card"></div>
             </section>
 
         </aside>

--- a/bcmi/src/app/static-pages/page/page.component.html
+++ b/bcmi/src/app/static-pages/page/page.component.html
@@ -4,6 +4,13 @@
             <div class="hero-banner__content">
                 <h1 id="pgTitle">{{pageData.Title}}</h1>
                 <p>{{pageData.Description}}</p>
+                <div class="hero-banner__content--cta-btns" *ngIf="pageData.Header_button !== null && pageData.Header_button !== undefined && pageData.Header_button.length > 0">
+                    <ng-container *ngFor="let button of pageData.Header_button">
+                        <a class="btn hero-btn inverted" [routerLink]="routerLink" [fragment]="button.Section_id">
+                            <span>{{button.Text}}</span>
+                        </a>&nbsp;
+                    </ng-container>
+                </div>
             </div>
         </div>
     </div>

--- a/bcmi/src/app/static-pages/page/page.component.html
+++ b/bcmi/src/app/static-pages/page/page.component.html
@@ -29,14 +29,10 @@
                 <div [innerHTML]="pageData.External_card"></div>
             </section>
 
-            <!----
-            <section class="card">
+            <section class="card" *ngIf="!(pageData.Enforcement_Actions_card === null ||  pageData.Enforcement_Actions_card === '')">
               <h4 class="card-header">Enforcement Actions</h4>
-              <ul class="nv-list">
-                  <<li><a href="/enforcement-actions" target="_blank" rel="noopener"> The Ministry of Energy, Mines, and Low Carbon Innovation </a></li>>
-              </ul>
-          </section>
-          --->
+              <div [innerHTML]="pageData.Enforcement_Actions_card"></div>
+            </section>
 
         </aside>
     </div>

--- a/bcmi/src/app/static-pages/page/page.component.html
+++ b/bcmi/src/app/static-pages/page/page.component.html
@@ -11,7 +11,7 @@
 
 <div class="container" id="anchor-point">
     <div class="row">
-        <main id="page-content" [ngClass]="{'col-lg-8': isTwoColumn}" content [innerHTML]="pageData.Content">
+        <main id="page-content" [ngClass]="{'col-lg-8': isTwoColumn}" content [innerHTML]="pageData.Content | safeHtml">
         </main>
         <aside *ngIf="isTwoColumn" class="col-lg-4">
             <section class="card" *ngIf="!(pageData.Ongoing_card === null ||  pageData.Ongoing_card === '')">

--- a/bcmi/src/app/static-pages/page/page.component.html
+++ b/bcmi/src/app/static-pages/page/page.component.html
@@ -18,27 +18,27 @@
 
 <div class="container" id="anchor-point">
     <div class="row">
-        <main id="page-content" [ngClass]="{'col-lg-8': isTwoColumn}" content [innerHTML]="pageData.Content | safeHtml">
+        <main id="page-content" [ngClass]="{'col-lg-8': isTwoColumn}" appContent [innerHTML]="pageData.Content | safeHtml">
         </main>
         <aside *ngIf="isTwoColumn" class="col-lg-4">
             <section class="card" *ngIf="!(pageData.Ongoing_card === null ||  pageData.Ongoing_card === '')">
                 <h4 class="card-header">Ongoing Lifecycle Activities</h4>
-                <div content [innerHTML]="pageData.Ongoing_card" class="card-body"></div>
+                <div appContent [innerHTML]="pageData.Ongoing_card" class="card-body"></div>
             </section>
 
             <section class="card" *ngIf="!(pageData.Related_card === null ||  pageData.Related_card === '')">
               <h4 class="card-header">Related Documents</h4>
-                <div content [innerHTML]="pageData.Related_card" class="card-list"></div>
+                <div appContent [innerHTML]="pageData.Related_card" class="card-list"></div>
             </section>
 
             <section class="card" *ngIf="!(pageData.External_card === null ||  pageData.External_card === '')">
                 <h4 class="card-header">External Links &amp; Resources</h4>
-                <div content [innerHTML]="pageData.External_card"></div>
+                <div appContent [innerHTML]="pageData.External_card"></div>
             </section>
 
             <section class="card" *ngIf="!(pageData.Enforcement_Actions_card === null ||  pageData.Enforcement_Actions_card === '')">
               <h4 class="card-header">Enforcement Actions</h4>
-              <div content [innerHTML]="pageData.Enforcement_Actions_card"></div>
+              <div appContent [innerHTML]="pageData.Enforcement_Actions_card"></div>
             </section>
 
         </aside>

--- a/bcmi/src/app/static-pages/page/page.component.spec.ts
+++ b/bcmi/src/app/static-pages/page/page.component.spec.ts
@@ -1,4 +1,5 @@
 import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
+import { SafeHtmlPipe } from '@pipes/safe-html.pipe';
 
 import { PageComponent } from './page.component';
 import { ActivatedRoute } from '@angular/router';
@@ -15,12 +16,20 @@ describe('PageComponent', () => {
   const pageData = new Page();
   pageData.Title = "Test";
 
-  const fakeActivatedRoute = {data: of({pageData: [pageData]}) };
+  const fakeActivatedRoute = {
+    data: of({pageData: [pageData]}),
+    fragment: of(null),
+    snapshot: {
+      routeConfig: {
+        path: '',
+      },
+    },
+  };
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       providers: [{provide: ActivatedRoute, useValue: fakeActivatedRoute}],
-      declarations: [PageComponent],
+      declarations: [PageComponent, SafeHtmlPipe],
       imports: [CommonModule]
     })
     .compileComponents();

--- a/bcmi/src/app/static-pages/page/page.component.ts
+++ b/bcmi/src/app/static-pages/page/page.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewEncapsulation } from '@angular/core';
+import { afterRender, Component, OnInit, ViewEncapsulation } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Page } from '../../models/content/page';
 
@@ -11,17 +11,39 @@ import { Page } from '../../models/content/page';
 export class PageComponent implements OnInit {
 
   pageData: Page;
+  fragment: string | null;
   isTwoColumn: boolean;
+  handledFragmentFlag: boolean;
 
-  constructor(private activatedRoute: ActivatedRoute){};
+  constructor(private activatedRoute: ActivatedRoute){
+    this.fragment = null;
+    afterRender(() => {
+      // Only need to do this once after our content loaded
+      if (this.handledFragmentFlag) { return; }
+      const contentHasLoaded = document.getElementById('page-content').hasChildNodes();
+      if (contentHasLoaded && this.fragment) {
+        this.jumpToSection(this.fragment);
+        this.handledFragmentFlag = true;
+      }
+    });
+  };
 
   ngOnInit() {
     window.scrollTo(0, 0);
     this.activatedRoute.data.subscribe((response: any) => {
       this.pageData = response.pageData;
-    })
+    });
+    this.activatedRoute.fragment.subscribe(fragment => {
+      this.fragment = fragment;
+    });
     // This conditional will need to be changed whenever sidecards are added to the template
     this.isTwoColumn = !!this.pageData.External_card || !!this.pageData.Ongoing_card || !!this.pageData.Related_card || !!this.pageData.Enforcement_Actions_card;
+  }
+
+  jumpToSection(section: string | null) {
+    if (section) {
+      document.getElementById(section)?.scrollIntoView({ behavior: 'smooth' });
+    }
   }
 
 }

--- a/bcmi/src/app/static-pages/page/page.component.ts
+++ b/bcmi/src/app/static-pages/page/page.component.ts
@@ -1,5 +1,5 @@
 import { afterRender, Component, OnInit, ViewEncapsulation } from '@angular/core';
-import { ActivatedRoute, RouterLink, RouterModule } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { Page } from '../../models/content/page';
 
 @Component({

--- a/bcmi/src/app/static-pages/page/page.component.ts
+++ b/bcmi/src/app/static-pages/page/page.component.ts
@@ -21,7 +21,7 @@ export class PageComponent implements OnInit {
       this.pageData = response.pageData;
     })
     // This conditional will need to be changed whenever sidecards are added to the template
-    this.isTwoColumn = !!this.pageData.External_card || !!this.pageData.Ongoing_card || !!this.pageData.Related_card;
+    this.isTwoColumn = !!this.pageData.External_card || !!this.pageData.Ongoing_card || !!this.pageData.Related_card || !!this.pageData.Enforcement_Actions_card;
     
   }
 

--- a/bcmi/src/app/static-pages/page/page.component.ts
+++ b/bcmi/src/app/static-pages/page/page.component.ts
@@ -1,5 +1,5 @@
 import { afterRender, Component, OnInit, ViewEncapsulation } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, RouterLink, RouterModule } from '@angular/router';
 import { Page } from '../../models/content/page';
 
 @Component({
@@ -11,18 +11,21 @@ import { Page } from '../../models/content/page';
 export class PageComponent implements OnInit {
 
   pageData: Page;
-  fragment: string | null;
+  routerLink: string;
+  initialFragment: string | null;
   isTwoColumn: boolean;
   handledFragmentFlag: boolean;
 
   constructor(private activatedRoute: ActivatedRoute){
-    this.fragment = null;
+    this.initialFragment = null;
+    this.routerLink = "/" + activatedRoute.snapshot.routeConfig.path;
+
     afterRender(() => {
       // Only need to do this once after our content loaded
       if (this.handledFragmentFlag) { return; }
       const contentHasLoaded = document.getElementById('page-content').hasChildNodes();
-      if (contentHasLoaded && this.fragment) {
-        this.jumpToSection(this.fragment);
+      if (contentHasLoaded && this.initialFragment) {
+        this.jumpToSection(this.initialFragment);
         this.handledFragmentFlag = true;
       }
     });
@@ -34,7 +37,7 @@ export class PageComponent implements OnInit {
       this.pageData = response.pageData;
     });
     this.activatedRoute.fragment.subscribe(fragment => {
-      this.fragment = fragment;
+      this.initialFragment = fragment;
     });
     // This conditional will need to be changed whenever sidecards are added to the template
     this.isTwoColumn = !!this.pageData.External_card || !!this.pageData.Ongoing_card || !!this.pageData.Related_card || !!this.pageData.Enforcement_Actions_card;

--- a/bcmi/src/app/static-pages/page/page.component.ts
+++ b/bcmi/src/app/static-pages/page/page.component.ts
@@ -16,13 +16,12 @@ export class PageComponent implements OnInit {
   constructor(private activatedRoute: ActivatedRoute){};
 
   ngOnInit() {
-    //window.scrollTo(0, 0);
+    window.scrollTo(0, 0);
     this.activatedRoute.data.subscribe((response: any) => {
       this.pageData = response.pageData;
     })
     // This conditional will need to be changed whenever sidecards are added to the template
     this.isTwoColumn = !!this.pageData.External_card || !!this.pageData.Ongoing_card || !!this.pageData.Related_card || !!this.pageData.Enforcement_Actions_card;
-    
   }
 
 }

--- a/cms/src/api/page/content-types/page/schema.json
+++ b/cms/src/api/page/content-types/page/schema.json
@@ -63,6 +63,11 @@
         "preset": "toolbar"
       },
       "customField": "plugin::ckeditor5.CKEditor"
+    },
+    "Header_button": {
+      "type": "component",
+      "repeatable": true,
+      "component": "page.scroll-button"
     }
   }
 }

--- a/cms/src/api/page/content-types/page/schema.json
+++ b/cms/src/api/page/content-types/page/schema.json
@@ -57,7 +57,7 @@
     "tooltip": {
       "type": "text"
     },
-    "Enforcement_card": {
+    "Enforcement_Actions_card": {
       "type": "customField",
       "options": {
         "preset": "toolbar"

--- a/cms/src/components/page/scroll-button.json
+++ b/cms/src/components/page/scroll-button.json
@@ -1,0 +1,16 @@
+{
+  "collectionName": "components_page_scroll_buttons",
+  "info": {
+    "displayName": "Scroll Button",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "Text": {
+      "type": "string"
+    },
+    "Section_id": {
+      "type": "string"
+    }
+  }
+}

--- a/cms/types/generated/components.d.ts
+++ b/cms/types/generated/components.d.ts
@@ -1,5 +1,17 @@
 import type { Schema, Attribute } from '@strapi/strapi';
 
+export interface PageScrollButton extends Schema.Component {
+  collectionName: 'components_page_scroll_buttons';
+  info: {
+    displayName: 'Scroll Button';
+    description: '';
+  };
+  attributes: {
+    Text: Attribute.String;
+    Section_id: Attribute.String;
+  };
+}
+
 export interface PageFeatureBlock extends Schema.Component {
   collectionName: 'components_page_feature_blocks';
   info: {
@@ -21,6 +33,7 @@ export interface PageFeatureBlock extends Schema.Component {
 declare module '@strapi/types' {
   export module Shared {
     export interface Components {
+      'page.scroll-button': PageScrollButton;
       'page.feature-block': PageFeatureBlock;
     }
   }

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -931,6 +931,7 @@ export interface ApiPagePage extends Schema.CollectionType {
           preset: 'toolbar';
         }
       >;
+    Header_button: Attribute.Component<'page.scroll-button', true>;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -924,7 +924,7 @@ export interface ApiPagePage extends Schema.CollectionType {
       >;
     route: Attribute.String & Attribute.Required;
     tooltip: Attribute.Text;
-    Enforcement_card: Attribute.RichText &
+    Enforcement_Actions_card: Attribute.RichText &
       Attribute.CustomField<
         'plugin::ckeditor5.CKEditor',
         {


### PR DESCRIPTION
- Added Enforcement Actions card and the buttons in the header to `PageComponent`
- Fixed fragment handling on pages and altered the header buttons to use fragments
- Added directive to turn relative `href`s into `routerLink`s and `fragment`s
- Removed static page routes